### PR TITLE
Patch fixes for current wine changes to bus_sdl.c

### DIFF
--- a/patches/proton/proton-sdl_joy.patch
+++ b/patches/proton/proton-sdl_joy.patch
@@ -2553,16 +2553,16 @@ diff --git a/dlls/winebus.sys/bus_sdl.c b/dlls/winebus.sys/bus_sdl.c
 index 55891138c87..8b6f0269965 100644
 --- a/dlls/winebus.sys/bus_sdl.c
 +++ b/dlls/winebus.sys/bus_sdl.c
-@@ -973,6 +973,9 @@ NTSTATUS WINAPI sdl_driver_init(DRIVER_OBJECT *driver, UNICODE_STRING *registry_
-         pSDL_JoystickGetProduct = wine_dlsym(sdl_handle, "SDL_JoystickGetProduct", NULL, 0);
-         pSDL_JoystickGetProductVersion = wine_dlsym(sdl_handle, "SDL_JoystickGetProductVersion", NULL, 0);
-         pSDL_JoystickGetVendor = wine_dlsym(sdl_handle, "SDL_JoystickGetVendor", NULL, 0);
+@@ -1161,6 +1161,9 @@
+         pSDL_JoystickGetProduct = dlsym(sdl_handle, "SDL_JoystickGetProduct");
+         pSDL_JoystickGetProductVersion = dlsym(sdl_handle, "SDL_JoystickGetProductVersion");
+         pSDL_JoystickGetVendor = dlsym(sdl_handle, "SDL_JoystickGetVendor");
 +        if(!pSDL_JoystickGetVendor){
 +            ERR("SDL installation is old! Please upgrade to >=2.0.6 to get accurate joystick information.\n");
 +        }
      }
  
-     sdl_driver_obj = driver;
+     map_controllers = check_bus_option(&controller_mode, 1);
 From c6ec16ae9643fc34f0d47881d90ff629990dc4a0 Mon Sep 17 00:00:00 2001
 From: Huw Davies <huw@codeweavers.com>
 Date: Mon, 22 Oct 2018 14:14:29 +0100


### PR DESCRIPTION
bus_sdl.c no longer uses libwine wrappers but dlopen()

refer to https://github.com/wine-mirror/wine/commit/3760b7a9f8597f29f99e8018938ba9c2c524cc62