### PR TITLE
Fixes for latest changes in wine

### DIFF
--- a/patches/proton/proton-sdl_joy.patch
+++ b/patches/proton/proton-sdl_joy.patch
@@ -2489,14 +2489,6 @@ diff --git a/dlls/dinput/joystick_sdl.c b/dlls/dinput/joystick_sdl.c
 index 147e680d17a..f7031524d13 100644
 --- a/dlls/dinput/joystick_sdl.c
 +++ b/dlls/dinput/joystick_sdl.c
-@@ -39,6 +39,7 @@
- 
- #include "wine/debug.h"
- #include "wine/unicode.h"
-+#include "wine/library.h"
- #include "wine/list.h"
- #include "windef.h"
- #include "winbase.h"
 @@ -112,6 +113,9 @@ static struct SDLDev *sdldevs = NULL;
  static void find_sdldevs(void)
  {
@@ -2511,10 +2503,10 @@ index 147e680d17a..f7031524d13 100644
      SDL_Init(SDL_INIT_JOYSTICK|SDL_INIT_HAPTIC);
      SDL_JoystickEventState(SDL_ENABLE);
  
-+    sdl_handle = wine_dlopen(SONAME_LIBSDL2, RTLD_NOW, NULL, 0);
++    sdl_handle = dlopen(SONAME_LIBSDL2, RTLD_NOW);
 +    if (sdl_handle) {
-+        pSDL_JoystickGetProduct = wine_dlsym(sdl_handle, "SDL_JoystickGetProduct", NULL, 0);
-+        pSDL_JoystickGetVendor = wine_dlsym(sdl_handle, "SDL_JoystickGetVendor", NULL, 0);
++        pSDL_JoystickGetProduct = dlsym(sdl_handle, "SDL_JoystickGetProduct");
++        pSDL_JoystickGetVendor = dlsym(sdl_handle, "SDL_JoystickGetVendor");
 +    }
 +
 +    if(!pSDL_JoystickGetVendor){
@@ -2553,16 +2545,16 @@ diff --git a/dlls/winebus.sys/bus_sdl.c b/dlls/winebus.sys/bus_sdl.c
 index 55891138c87..8b6f0269965 100644
 --- a/dlls/winebus.sys/bus_sdl.c
 +++ b/dlls/winebus.sys/bus_sdl.c
-@@ -973,6 +973,9 @@ NTSTATUS WINAPI sdl_driver_init(DRIVER_OBJECT *driver, UNICODE_STRING *registry_
-         pSDL_JoystickGetProduct = wine_dlsym(sdl_handle, "SDL_JoystickGetProduct", NULL, 0);
-         pSDL_JoystickGetProductVersion = wine_dlsym(sdl_handle, "SDL_JoystickGetProductVersion", NULL, 0);
-         pSDL_JoystickGetVendor = wine_dlsym(sdl_handle, "SDL_JoystickGetVendor", NULL, 0);
+@@ -1161,6 +1161,9 @@
+         pSDL_JoystickGetProduct = dlsym(sdl_handle, "SDL_JoystickGetProduct");
+         pSDL_JoystickGetProductVersion = dlsym(sdl_handle, "SDL_JoystickGetProductVersion");
+         pSDL_JoystickGetVendor = dlsym(sdl_handle, "SDL_JoystickGetVendor");
 +        if(!pSDL_JoystickGetVendor){
 +            ERR("SDL installation is old! Please upgrade to >=2.0.6 to get accurate joystick information.\n");
 +        }
      }
  
-     sdl_driver_obj = driver;
+     map_controllers = check_bus_option(&controller_mode, 1);
 From c6ec16ae9643fc34f0d47881d90ff629990dc4a0 Mon Sep 17 00:00:00 2001
 From: Huw Davies <huw@codeweavers.com>
 Date: Mon, 22 Oct 2018 14:14:29 +0100


### PR DESCRIPTION
Refer to https://github.com/wine-mirror/wine/commit/3caa3331279be2c99747cde8e369011378b38e31
bcrypt now uses dlopen instead libwine so wine_dlsym and wine_dlopen are no longer used.