### PR TITLE
Multiple fixes for current changes in wine

### DIFF
--- a/patches/proton/valve_proton_fullscreen_hack-staging.patch
+++ b/patches/proton/valve_proton_fullscreen_hack-staging.patch
@@ -2121,8 +2121,8 @@ index fecf9ab502..e53154d1ef 100644
  static void WINAPI wine_vkDestroyValidationCacheEXT(VkDevice device, VkValidationCacheEXT validationCache, const VkAllocationCallbacks *pAllocator)
  {
      TRACE("%p, 0x%s, %p\n", device, wine_dbgstr_longlong(validationCache), pAllocator);
-@@ -4348,12 +4276,6 @@ static VkResult WINAPI wine_vkGetPhysicalDeviceSupportedFramebufferMixedSamplesC
-     return physicalDevice->instance->funcs.p_vkGetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV(physicalDevice->phys_dev, pCombinationCount, pCombinations);
+@@ -4559,12 +4559,6 @@
+ #endif
  }
  
 -VkResult WINAPI wine_vkGetPhysicalDeviceSurfaceCapabilitiesKHR(VkPhysicalDevice physicalDevice, VkSurfaceKHR surface, VkSurfaceCapabilitiesKHR *pSurfaceCapabilities)
@@ -2131,9 +2131,9 @@ index fecf9ab502..e53154d1ef 100644
 -    return physicalDevice->instance->funcs.p_vkGetPhysicalDeviceSurfaceCapabilitiesKHR(physicalDevice->phys_dev, surface, pSurfaceCapabilities);
 -}
 -
- VkResult WINAPI wine_vkGetPhysicalDeviceSurfaceFormatsKHR(VkPhysicalDevice physicalDevice, VkSurfaceKHR surface, uint32_t *pSurfaceFormatCount, VkSurfaceFormatKHR *pSurfaceFormats)
+ static VkResult WINAPI wine_vkGetPhysicalDeviceSurfaceFormats2KHR(VkPhysicalDevice physicalDevice, const VkPhysicalDeviceSurfaceInfo2KHR *pSurfaceInfo, uint32_t *pSurfaceFormatCount, VkSurfaceFormat2KHR *pSurfaceFormats)
  {
-     TRACE("%p, 0x%s, %p, %p\n", physicalDevice, wine_dbgstr_longlong(surface), pSurfaceFormatCount, pSurfaceFormats);
+ #if defined(USE_STRUCT_CONVERSION)
 @@ -4477,12 +4399,6 @@ static VkResult WINAPI wine_vkGetShaderInfoAMD(VkDevice device, VkPipeline pipel
      return device->funcs.p_vkGetShaderInfoAMD(device->device, pipeline, shaderStage, infoType, pInfoSize, pInfo);
  }
@@ -2880,7 +2880,7 @@ index 635c7d9f3b..5b5ebe2d6e 100644
 +    REDIRECT( glReadBuffer );
  #undef REDIRECT
  
-     pglXGetProcAddressARB = wine_dlsym(opengl_handle, "glXGetProcAddressARB", NULL, 0);
+     pglXGetProcAddressARB = dlsym(opengl_handle, "glXGetProcAddressARB");
 @@ -583,6 +624,22 @@ static BOOL WINAPI init_opengl( INIT_ONCE *once, void *param, void **context )
          goto failed;
      }


### PR DESCRIPTION
VK_KHR_get_surface_capabilities2 got implemented into wine refer to https://github.com/wine-mirror/wine/commit/086c686e817a596e35c41dd5b37f3c28587af9d5 and bcrypt now uses dlopen instead libwine so wine_dlsym is no longer used refer to https://github.com/wine-mirror/wine/commit/3caa3331279be2c99747cde8e369011378b38e31