### PR TITLE
bcrypt no longer uses libwine

### DIFF
--- a/patches/proton/proton-protonify_staging.patch
+++ b/patches/proton/proton-protonify_staging.patch
@@ -2979,11 +2979,11 @@ index 868f898bbbb..95f498123ea 100644
 +++ b/dlls/bcrypt/gnutls.c
 @@ -267,8 +267,11 @@ BOOL gnutls_initialize(void)
      }
-     if (!(pgnutls_decode_rs_value = wine_dlsym( libgnutls_handle, "gnutls_decode_rs_value", NULL, 0 )))
+     if (!(pgnutls_decode_rs_value = dlsym( libgnutls_handle, "gnutls_decode_rs_value")))
      {
 -        WARN("gnutls_decode_rs_value not found\n");
 -        pgnutls_decode_rs_value = compat_gnutls_decode_rs_value;
-+        if (!(pgnutls_decode_rs_value = wine_dlsym( libgnutls_handle, "_gnutls_decode_ber_rs_raw", NULL, 0)))
++        if (!(pgnutls_decode_rs_value = dlsym( libgnutls_handle, "_gnutls_decode_ber_rs_raw")))
 +        {
 +            WARN("gnutls_decode_rs_value and legacy alternative _gnutls_decode_ber_rs_raw not found\n");
 +            pgnutls_decode_rs_value = compat_gnutls_decode_rs_value;


### PR DESCRIPTION
Refer to https://github.com/wine-mirror/wine/commit/3caa3331279be2c99747cde8e369011378b38e31
bcrypt now uses dlopen instead libwine so wine_dlsym is no longer used.