### PR TITLE
Proton system install readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,8 +109,12 @@ Full patches can be viewed in [protonprep.sh](patches/protonprep.sh).
 This section is for those that use the native version of Steam.
 
 1. Download a release from the [Releases](https://github.com/GloriousEggroll/proton-ge-custom/releases) page.
-2. Create a `~/.steam/root/compatibilitytools.d` directory if it does not exist.
-3. Extract the release tarball into `~/.steam/root/compatibilitytools.d/`.
+2. Either create a directory in one of the following locations, if missing:
+   - `~/.steam/root/compatibilitytools.d` -- single-user installation;
+   - `/usr/share/steam/compatibilitytools.d` -- system wide installation (will probably need root permissions);
+   - `/usr/local/share/steam/compatibilitytools.d` -- system wide installation (will probably need root permissions);
+   - one of the directories specified in the `STEAM_EXTRA_COMPAT_TOOLS_PATHS` environment variable, if used.
+3. Extract the release tarball into one of the previous paths, i.e. `~/.steam/root/compatibilitytools.d/` or `/usr/share/steam/compatibilitytools.d/` or `/usr/local/share/steam/compatibilitytools.d` or a path in `STEAM_EXTRA_COMPAT_TOOLS_PATHS`.
 4. Restart Steam.
 5. [Enable proton-ge-custom](#enabling).
 


### PR DESCRIPTION
After ValveSoftware/Proton#3845 got merged in ValveSoftware/Proton@6e821c774fce67e35cedc2d193853c9333a1922f, Proton-GE releases can now be installed in the system-wide directory `/usr/share/steam/compatibilitytools.d` that is already supported by the Steam client (see ValveSoftware/steam-for-linux#6310).

I propose to update the README.md file to add this bit of information that can be useful especially to distro packagers.