### PR TITLE
Amend Markdown formatting for shell commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,36 +130,49 @@ This section is for those that use the Flatpak'd version of Steam.
 2. Install Vagrant.
 3. Clone this repo by executing:
 
-```
-git clone --recurse-submodules http://github.com/gloriouseggroll/proton-ge-custom
+```sh
+	git clone --recurse-submodules http://github.com/gloriouseggroll/proton-ge-custom
 ```
 
-4. Drop any custom patches into patches/, then open patches/protonprep.sh and add a patch line for them under #WINE CUSTOM PATCHES in the same way the others are done. 
+4. Drop any custom patches into patches/, then open patches/protonprep.sh and add a patch line for them under `#WINE CUSTOM PATCHES` in the same way the others are done. 
 
 5. Apply all of the patches in patches/ by running:
 
-```
-./patches/protonprep-nofshack.sh &> patchlog.txt
+```sh
+	./patches/protonprep-nofshack.sh &> patchlog.txt
 ```
 
 in the main proton-ge-custom directory. Open `patchlog.txt` and search for "fail" to make sure no patch failures occured. An easy way to do this is like so:
 
-grep -i fail patchlog.txt
-grep -i error patchlog.txt 
+```sh
+	grep -i fail patchlog.txt
+	grep -i error patchlog.txt 
+```
 
 6. Open proton-ge-custom a terminal and type the following:
 
-`vagrant up` (On the first run choose yes, it will ask you to run vagrant up again)  
-`vagrant up` (this will take a while on the first run, as it prepares everything)  
-`build_name=some_custom_build_name make redist | tee buildlog.txt` (this will start the build and log everything to buildlog.txt so that you can review the log if something fails)  
-`vagrant halt` (this will shut down the build afterwards)  
+```sh
+	# On the first run choose yes, it will ask you to run vagrant up again
+	vagrant up
+	# This will take a while on the first run, as it prepares everything
+	vagrant up
+
+	# This will start the build and log everything to buildlog.txt
+	# so that you can review the log if something fails)
+	build_name=some_custom_build_name make redist | tee buildlog.txt 
+
+	# This will shut down the build afterwards
+	vagrant halt
+```
 
 For future builds you only need to run:  
 
-`build_name=some_custom_build_name make redist`  
-`vagrant halt`  
+```sh
+	build_name=some_custom_build_name make redist
+	vagrant halt
+```  
 
-Builds will be placed in proton-ge-custom/vagrant_share/ as both the full folder and a .tar.gz of the folder.
+Builds will be placed in `proton-ge-custom/vagrant_share/` as both the full folder and a `.tar.gz` of the folder.
 
 ## Enabling
 


### PR DESCRIPTION
Some parts of the README have sections for shell commands. I added syntax highlighting for `sh` and added an indent for these commands in code block sections. While GitHub doesn't use this much from what I can see, some Markdown preview tools will make better use of having the language explicitly specified. The `grep` command section was also not formatted, so I added it as a code block.

I went with an indent for these sections to be consistent with the upstream Proton readme, but if there is a preference on how to format this (perhaps with an `$` or `%`) then I can go ahead and fix that.

Step 6 of the Vagrant instructions were moved into a big code block, and the instructions to the sides of each command in brackets was instead moved to a comment above each command. If this is not acceptable I can change it back or format it in a preferred way.

If there is any additional formatting I should amend, feedback is always welcome.

Thanks!