### PR TITLE
Removed fixed issues from Notes section of readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,8 +115,6 @@ This is my build of Proton with the most recent releases of vanilla WINE. It has
 - Warframe is problematic with VSync. Turn it off or on in game, do not set to `Auto`
 - Warframe needs a set a frame limit in game. Unlimited framerate can cause slowdowns
 - Warframe on Nvidia: you may need to disable GPU Particles in game otherwise the game can freeze randomly. On AMD they work fine
-- Borderlands 3 Marcus game intro audio will freeze halfway through if you don't skip it. Rest of the game is playable and videos work
-- Soul Calibur VI main menu will freeze of you don't press a button before the audio ends. Rest of the game is playable and videos work
 - Injustice 2 and MK11 are missing cutscene audio
 
 Full patches can be viewed in [protonprep.sh](patches/protonprep.sh).

--- a/README.md
+++ b/README.md
@@ -52,8 +52,8 @@ This is my build of Proton with the most recent releases of vanilla WINE. It has
 - Mount and Blade Warband
 - Divinity Original Sin 2
 - Sea of Thieves
-- Death Stranding
-- Horizon Zero Dawn
+- Death Stranding fixes
+- Horizon Zero Dawn fixes
 - Fall Guys controller mapping fix
 - World War Z Vulkan renderer fix
 - rFactor 2
@@ -69,8 +69,6 @@ This is my build of Proton with the most recent releases of vanilla WINE. It has
 - Just Cause 4 fixes
 - Age of Empires II: DE Online Multiplayer fixed
 - Halo: MCC Online coop campaign fixed
-- Death Stranding fixes
-- Horizon Zero Dawn fixes
 
 ### Non-Steam or winesteam game patches
 


### PR DESCRIPTION
Borderlands 3 and Soul Calibur VI issues fixed in latest Proton 5.21-GE-1 release.

> - Soul Calibur VI no longer freezes at the main menu, should be fully playable
> - Borderlands 3 should be fully playable (including Markus intro)

Hopefully it's not too premature to remove these!