### PR TITLE
msiexec needed for xna31.msi and others

### DIFF
--- a/build/makefile_base.mak
+++ b/build/makefile_base.mak
@@ -1733,7 +1733,7 @@ wine64-intermediate: $(WINE_CONFIGURE_FILES64)
 	+$(MAKE) -C $(WINE_OBJ64) $(WINE64_MAKE_ARGS) install-lib install-dev
 	if [ "$(UNSTRIPPED_BUILD)" == "" ]; then rm -rf $(DST_DIR)/lib64/wine/.debug; fi
 	if [ "$(UNSTRIPPED_BUILD)" != "" ]; then make -C $(WINE_OBJ64) $(WINE64_MAKE_ARGS) install-cross-debug; cp -af $(TOOLS_DIR64)/lib64/wine/.debug $(DST_DIR)/lib64/wine/; fi
-	rm -f $(DST_DIR)/bin/{msiexec,notepad,regedit,regsvr32,wineboot,winecfg,wineconsole,winedbg,winefile,winemine,winepath}
+	rm -f $(DST_DIR)/bin/{notepad,regedit,regsvr32,wineboot,winecfg,wineconsole,winedbg,winefile,winemine,winepath}
 	rm -rf $(DST_DIR)/share/man/
 
 ## This installs 32-bit stuff manually, see


### PR DESCRIPTION
some games like _**Kung Fu Strike Warrior's Rise**_, need **_XNA31_**, which is `xnafx31_redist.msi`. without msiexec how is it possible to install msi files?