### PR TITLE
Build proton on Github actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,65 @@
+on:
+  push:
+    tags:    
+      - "*"
+
+jobs:
+  build-proton-ge:
+    runs-on: macos-10.15
+    env:
+      # avoids hanging the system with vagrant checking for updates
+      VAGRANT_CHECKPOINT_DISABLE: yes
+      # Extract the tag name without refs/tags
+      RELEASE_VERSION: ${GITHUB_REF#refs/*/}
+      # Dedicated file for github actions compatible 
+      # with the gh-actions environment
+      VAGRANT_VAGRANTFILE: Vagrantfile.github
+    steps:
+      - name: Display version
+        run: echo ${{ env.RELEASE_VERSION }}
+
+      - name: Install dependencies
+        run: brew install coreutils
+      # would be a shame to wait 2 hours for the
+      # compilation to finish only to realise sha512sum is not
+      # available
+      - name: Test sha512sum availability
+        run: echo "hello" | sha512sum
+
+      - uses: actions/checkout@master
+        with:
+          submodules: false
+
+      - name: Update submodules
+        run: |
+          set -o xtrace
+          git submodule update --init --recursive
+          
+      - name: Show Vagrant version
+        run: vagrant --version
+      
+        # without this the share directory mounting fails
+        # probably because the guest additions are old
+      - name: Setup vbox additions
+        run: vagrant plugin install vagrant-vbguest
+
+      - name: apply patches
+        run: ./patches/protonprep.sh
+
+      - name: Run vagrant up
+        run: vagrant up --no-tty
+      - name: Run vagrant up
+        run: vagrant up --no-tty
+
+      # Build name following convention: Proton-<tag>
+      - name: Build proton
+        run: build_name=Proton-${{ env.RELEASE_VERSION }} make redist
+
+      - name: Upload binaries to release
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GH_PAT }}
+          file: vagrant_share/*
+          file_glob: true
+          tag: ${{ github.ref }}
+          overwrite: false

--- a/Vagrantfile.github
+++ b/Vagrantfile.github
@@ -1,0 +1,110 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.require_version ">= 2.2.0"
+
+module OS
+  def OS.windows?
+    (/cygwin|mswin|mingw|bccwin|wince|emx/ =~ RUBY_PLATFORM) != nil
+  end
+
+  def OS.mac?
+    (/darwin/ =~ RUBY_PLATFORM) != nil
+  end
+
+  def OS.unix?
+    !OS.windows?
+  end
+
+  def OS.linux?
+    OS.unix? and not OS.mac?
+  end
+end
+
+# Vagrant file for setting up a build environment for Proton.
+if OS.linux?
+  cpus = `nproc`.to_i
+  # meminfo shows KB and we need to convert to MB
+  memory = `grep 'MemTotal' /proc/meminfo | sed -e 's/MemTotal://' -e 's/ kB//'`.to_i / 1024 / 4
+elsif OS.mac?
+  cpus = `sysctl -n hw.physicalcpu`.to_i
+  # sysctl shows bytes and we need to convert to MB
+  memory = `sysctl hw.memsize | sed -e 's/hw.memsize: //'`.to_i / 1024 / 1024 / 4
+else
+  cpus = 1
+  memory = 1024
+  puts "Vagrant launched from unsupported platform."
+end
+memory = [memory, 4096].max
+puts "Platform: " + cpus.to_s + " CPUs, " + memory.to_s + " MB memory"
+
+Vagrant.configure(2) do |config|
+  #libvirt doesn't have a decent synced folder, so we have to use vagrant-sshfs.
+  #This is not needed for virtualbox, but I couldn't find a way to use a
+  #different synced folder type per provider, so we always use it.
+  
+  # if you are using libvirt uncomment the below. Because github
+  # action runs outside a tty and uses virtualbox, there's no need for this plugin 
+  # config.vagrant.plugins = "vagrant-sshfs"
+
+  config.vm.provider "virtualbox" do |v|
+    v.cpus = [cpus, 32].min     # virtualbox limit is 32 cpus
+    v.memory = memory
+  end
+
+  config.vm.provider "libvirt" do |v|
+    v.cpus = cpus
+    v.memory = memory
+    v.random_hostname = true
+    v.default_prefix = ENV['USER'].to_s.dup.concat('_').concat(File.basename(Dir.pwd))
+  end
+
+  #debian10-based build VM
+  config.vm.define "debian10", primary: true do |debian10|
+
+    debian10.vm.box = "generic/debian10"
+
+    debian10.vm.synced_folder "./vagrant_share/", "/vagrant/", create: true
+    debian10.vm.synced_folder ".", "/home/vagrant/proton", id: "proton", type: "rsync", rsync__exclude: ["vagrant_share"]
+
+    debian10.vm.provision "shell", privileged: "true", inline: <<-SHELL
+      #install docker and steam-runtime dependencies
+      dpkg --add-architecture i386
+      apt-get update
+      apt-get install -y apt-transport-https ca-certificates curl gnupg2 software-properties-common
+
+      #add docker repo
+      curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add -
+      add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/debian buster stable"
+
+      #install host build-time dependencies
+      apt-get update
+      apt-get install -y ccache texinfo gpgv2 gnupg2 git docker-ce docker-ce-cli containerd.io \
+          fontforge-nox python-debian python-pip python3-pefile
+
+      # use python 3 to avoid python2 afdko breakage
+      apt-get install -y python3-pip
+      update-alternatives --install /usr/bin/python python /usr/bin/python3 1
+
+      #install adobe font devkit to build source san hans
+      pip install afdko
+
+      #work around an afdko dependency bug
+      pip install singledispatch==3.4.0.4
+
+      #allow vagrant user to run docker
+      adduser vagrant docker
+
+      # use faster overlay2 docker driver
+      echo '{"storage-driver": "overlay2"}' >/etc/docker/daemon.json
+
+      #allow user to run stuff in steamrt
+      sysctl kernel.unprivileged_userns_clone=1
+      mkdir -p /etc/sysctl.d/
+      echo kernel.unprivileged_userns_clone=1 > /etc/sysctl.d/docker_user.conf
+
+      #ensure we use only the mingw-w64 that we built
+      apt-get remove -y '*mingw-w64*'
+    SHELL
+  end
+end


### PR DESCRIPTION
## Summary
- Proton is built on a mac 10.15 environment because it's the only one provided that has virtualisation (has VirtualBox and vagrant already installed)
- vagrant-sshfs requires a tty but it's not needed with virtual box so I commented it out.
- Build takes about 2 hours

## Prerequisites
- In order for the tarball and shasum to be uploaded to the release a personal access token is needed (named GH_PAT)

### Create personal access token
1. In Settings > Developer create new repository secret
![access_token_screen](https://user-images.githubusercontent.com/3875429/117535055-ea6b2d80-afeb-11eb-9115-a890c4c2417e.png)

2. These are the permissions I gave to my secret (it probably doesn't need access to discussions, I had problems with another action related to goreleaser)

![access_token_permissions1](https://user-images.githubusercontent.com/3875429/117535093-0a025600-afec-11eb-8340-88317f7ba1fc.png)
![access_token_permissions2](https://user-images.githubusercontent.com/3875429/117535097-0c64b000-afec-11eb-9f06-3df1d1becfb5.png)

3. Copy the token value over to the project secrets

![create_secret](https://user-images.githubusercontent.com/3875429/117535028-cad40500-afeb-11eb-9d92-a16b6b04bccc.png)
 

It will be a good idea to test this before running the whole thing as it takes about two hours, this was my test : https://github.com/vaslabs/proton-ge-custom/blob/56f7c1898c1ea8927c17947024de95cb8302b7e4/.github/workflows/release.yml
 

## Results
- Successful workflow: https://github.com/vaslabs/proton-ge-custom/actions/runs/822623394
- Release: https://github.com/vaslabs/proton-ge-custom/releases/tag/6.7-GE-RC-16