### PR TITLE
6.19 ge 2 evepatch

### DIFF
--- a/patches/protonprep.sh
+++ b/patches/protonprep.sh
@@ -291,6 +291,9 @@
     echo "EA Desktop fix (for new EA beta client)"
     patch -Np1 < ../patches/wine-hotfixes/pending/hotfix-EA_desktop_fix.patch
 
+    echo "RaceRoom fix"
+    patch -Np1 < ../patches/wine-hotfixes/testing/0001-wininet-Support-option-INTERNET_OPTION_SERVER_CERT_C.patch
+
 
 ### END WINE PENDING UPSTREAM SECTION ###
 

--- a/patches/protonprep.sh
+++ b/patches/protonprep.sh
@@ -300,6 +300,7 @@
 
 ### (2-7) WINE CUSTOM PATCHES ###
 
+    # https://bugs.winehq.org/show_bug.cgi?id=51821
     echo "EVE Online - Fixe launcher 19.09"
     patch -Np1 < ../patches/wine-hotfixes/eveonline/70739.patch
 

--- a/patches/protonprep.sh
+++ b/patches/protonprep.sh
@@ -300,6 +300,8 @@
 
 ### (2-7) WINE CUSTOM PATCHES ###
 
+    echo "EVE Online - Fixe launcher 19.09"
+    patch -Np1 < ../patches/wine-hotfixes/eveonline/70739.patch
 
 ### END WINE CUSTOM PATCHES ###
 ### END WINE PATCHING ###

--- a/patches/wine-hotfixes/eveonline/70739.patch
+++ b/patches/wine-hotfixes/eveonline/70739.patch
@@ -1,0 +1,27 @@
+From 199c27d907eafbb52fb3cd0a66807624fd7b920f Mon Sep 17 00:00:00 2001
+From: algebro <algebro at tuta dot io>
+Date: Tue, 5 Oct 2021 16:24:52 -0400
+Subject: [PATCH] append exe directory to dll path with
+ LOAD_WITH_ALTERED_SEARCH_PATH
+
+---
+ dlls/ntdll/loader.c | 3 +--
+ 1 file changed, 1 insertion(+), 2 deletions(-)
+
+diff --git a/dlls/ntdll/loader.c b/dlls/ntdll/loader.c
+index 3e3f991eba2..37472188900 100644
+--- a/dlls/ntdll/loader.c
++++ b/dlls/ntdll/loader.c
+@@ -4182,8 +4182,7 @@ NTSTATUS WINAPI LdrGetDllPath( PCWSTR module, ULONG flags, PWSTR *path, PWSTR *u
+     else
+     {
+         const WCHAR *dlldir = dll_directory.Length ? dll_directory.Buffer : NULL;
+-        if (!(flags & LOAD_WITH_ALTERED_SEARCH_PATH))
+-            module = NtCurrentTeb()->Peb->ProcessParameters->ImagePathName.Buffer;
++        module = NtCurrentTeb()->Peb->ProcessParameters->ImagePathName.Buffer;
+         status = get_dll_load_path( module, dlldir, dll_safe_mode, path );
+     }
+ 
+-- 
+2.33.0
+

--- a/patches/wine-hotfixes/testing/0001-wininet-Support-option-INTERNET_OPTION_SERVER_CERT_C.patch
+++ b/patches/wine-hotfixes/testing/0001-wininet-Support-option-INTERNET_OPTION_SERVER_CERT_C.patch
@@ -1,0 +1,36 @@
+From 57e993f39d97db71434e90320092dc442a098eb1 Mon Sep 17 00:00:00 2001
+From: Alistair Leslie-Hughes <leslie_alistair@hotmail.com>
+Date: Mon, 11 Oct 2021 13:44:40 +1100
+Subject: [PATCH] wininet: Support option
+ INTERNET_OPTION_SERVER_CERT_CHAIN_CONTEXT for http connections
+
+Signed-off-by: Alistair Leslie-Hughes <leslie_alistair@hotmail.com>
+---
+ dlls/wininet/http.c | 11 +++++++++++
+ 1 file changed, 11 insertions(+)
+
+diff --git a/dlls/wininet/http.c b/dlls/wininet/http.c
+index 8e40a4cee2b..aef29f28caf 100644
+--- a/dlls/wininet/http.c
++++ b/dlls/wininet/http.c
+@@ -2330,6 +2330,17 @@ static DWORD HTTPREQ_QueryOption(object_header_t *hdr, DWORD option, void *buffe
+ 
+         *(ULONG*)buffer = hdr->ErrorMask;
+         *size = sizeof(ULONG);
++        return ERROR_SUCCESS;
++    case INTERNET_OPTION_SERVER_CERT_CHAIN_CONTEXT:
++        TRACE("INTERNET_OPTION_SERVER_CERT_CHAIN_CONTEXT\n");
++
++        if (*size < sizeof(PCERT_CHAIN_CONTEXT))
++            return ERROR_INSUFFICIENT_BUFFER;
++
++        if(req->server->cert_chain)
++            *((PCERT_CHAIN_CONTEXT*)buffer) = (PCERT_CHAIN_CONTEXT)CertDuplicateCertificateChain(req->server->cert_chain);
++        *size = sizeof(PCERT_CHAIN_CONTEXT);
++
+         return ERROR_SUCCESS;
+     }
+ 
+-- 
+2.33.0
+


### PR DESCRIPTION
19.09 eve launcher is again buggy,
You can find the patch to correct it [here](https://bugs.winehq.org/show_bug.cgi?id=51821)

This pull request is to make it permanent in proton-ge.

Thank you for your work