### PR TITLE
patch to workaround bug in castlevania advance

### DIFF
--- a/patches/game-patches/castlevania-advance-collection.patch
+++ b/patches/game-patches/castlevania-advance-collection.patch
@@ -1,0 +1,12 @@
+diff --git a/dlls/ntdll/unix/file.c b/dlls/ntdll/unix/file.c
+index 7e47e32bab9..91d008475e1 100644
+--- a/dlls/ntdll/unix/file.c
++++ b/dlls/ntdll/unix/file.c
+@@ -3160,6 +3160,7 @@ static NTSTATUS lookup_unix_name( const WCHAR *name, int name_len, char **buffer
+         {
+             if (!*ptr) return STATUS_OBJECT_NAME_INVALID;
+             if (is_unix) continue;
++            if (*ptr == '?') continue; // some games put a ? in filenames on failure of un-implemented features, ignore this
+             if (*ptr < 32 || wcschr( invalid_charsW, *ptr )) return STATUS_OBJECT_NAME_INVALID;
+         }
+     }


### PR DESCRIPTION
Works around  the looping "No space available" bug in Castlevania Advance Collection, tested and playing all the games + savegames now work.  Should not break other applications but cannot test to be sure.