### PR TITLE
add workaround for The Good Life (1452500)

### DIFF
--- a/patches/game-patches/thegoodlife-mfplat-http-scheme-workaround.patch
+++ b/patches/game-patches/thegoodlife-mfplat-http-scheme-workaround.patch
@@ -1,0 +1,314 @@
+From 26b7ef4aa5fb55f7044e4eb3809675c34f5de2ab Mon Sep 17 00:00:00 2001
+From: Philipp Richter <richterphilipp.pops@gmail.com>
+Date: Tue, 19 Oct 2021 11:56:11 +0200
+Subject: [PATCH] mfplat: workaround for "The Good Life (1452500)" due
+ to missing "http:" scheme implementation
+
+"The Good Life (1452500)" wants to load its video files over http: but
+that fails due to the missing implementation in wine.
+
+This workaround pulls the Content-Length from the response headers and
+attempts to match the right file in the game folder to serve it using
+the "file:" scheme.
+
+See: https://github.com/ValveSoftware/Proton/issues/5195
+---
+ dlls/mfplat/Makefile.in |   2 +-
+ dlls/mfplat/main.c      | 226 ++++++++++++++++++++++++++++++++++++++++
+ 2 files changed, 227 insertions(+), 1 deletion(-)
+
+diff --git a/dlls/mfplat/Makefile.in b/dlls/mfplat/Makefile.in
+index 9e5c607deae..bc5e13aaa7f 100644
+--- a/dlls/mfplat/Makefile.in
++++ b/dlls/mfplat/Makefile.in
+@@ -1,6 +1,6 @@
+ MODULE    = mfplat.dll
+ IMPORTLIB = mfplat
+-IMPORTS   = advapi32 ole32 mfuuid propsys rtworkq
++IMPORTS   = advapi32 ole32 mfuuid propsys rtworkq kernelbase wininet
+ 
+ EXTRADLLFLAGS = -mno-cygwin -Wb,--prefer-native
+ 
+diff --git a/dlls/mfplat/main.c b/dlls/mfplat/main.c
+index 519fa23cd23..b4ce5e14a0e 100644
+--- a/dlls/mfplat/main.c
++++ b/dlls/mfplat/main.c
+@@ -46,6 +46,8 @@
+ #include "strsafe.h"
+ #undef INITGUID
+ #include "evr.h"
++#include "pathcch.h"
++#include "wininet.h"
+ 
+ WINE_DEFAULT_DEBUG_CHANNEL(mfplat);
+ 
+@@ -6254,6 +6256,185 @@ static ULONG WINAPI source_resolver_Release(IMFSourceResolver *iface)
+     return refcount;
+ }
+ 
++/*
++ * Applies The Good Life (1452500) workaround for http: scheme urls
++ * Retrieves the Content-Length response header from the http request
++ * and matches it with the game files to find the direct path
++ * temp_buffer should be PATHCCH_MAX_CCH characters long for extended path support
++ * the new url will be placed into temp_buffer
++ */
++static BOOL thegoodlife_workaround_url_matcher(const WCHAR *url, WCHAR *temp_buffer, DWORD temp_buffer_size)
++{
++    static const WCHAR* acccept_types[] = { L"*/*", NULL };
++    URL_COMPONENTSW url_comp;
++    HINTERNET hinternet, hconnect, hrequest;
++    WCHAR content_length[24];
++    DWORD content_length_size;
++    WIN32_FIND_DATAW find_file_data;
++    HANDLE hfind;
++    DWORDLONG size, file_size;
++    content_length_size = sizeof(content_length);
++
++    memset(&url_comp, 0, sizeof(URL_COMPONENTSW));
++    url_comp.dwStructSize = sizeof(URL_COMPONENTSW);
++    url_comp.dwHostNameLength = 1;
++    url_comp.dwUserNameLength = 1;
++    url_comp.dwPasswordLength = 1;
++    url_comp.dwUrlPathLength = 1;
++    url_comp.dwExtraInfoLength = 1;
++
++    if (!(InternetCrackUrlW(url, lstrlenW(url), 0, &url_comp)))
++    {
++        WARN("InternetCrackUrlW failed: %d\n", GetLastError());
++        return FALSE;
++    }
++
++    /* write 0 terminated components into the temp_buffer */
++    if ((url_comp.dwHostNameLength + 1 +
++        url_comp.dwUserNameLength + 1 +
++        url_comp.dwPasswordLength + 1 +
++        url_comp.dwUrlPathLength + url_comp.dwExtraInfoLength + 1) > temp_buffer_size)
++    {
++        WARN("temp_buffer is too small\n", GetLastError());
++        return FALSE;
++    }
++
++    url_comp.lpszHostName = memcpy(temp_buffer, url_comp.lpszHostName, url_comp.dwHostNameLength * sizeof(WCHAR));
++    url_comp.lpszHostName[url_comp.dwHostNameLength] = 0;
++    url_comp.lpszUserName = memcpy(url_comp.lpszHostName + url_comp.dwHostNameLength + 1, url_comp.lpszUserName,
++        url_comp.dwUserNameLength * sizeof(WCHAR));
++    url_comp.lpszUserName[url_comp.dwUserNameLength] = 0;
++    url_comp.lpszPassword = memcpy(url_comp.lpszUserName + url_comp.dwUserNameLength + 1, url_comp.lpszPassword,
++        url_comp.dwPasswordLength * sizeof(WCHAR));
++    url_comp.lpszPassword[url_comp.dwPasswordLength] = 0;
++    url_comp.lpszUrlPath = memcpy(url_comp.lpszPassword + url_comp.dwPasswordLength + 1, url_comp.lpszUrlPath,
++        (url_comp.dwUrlPathLength + url_comp.dwExtraInfoLength) * sizeof(WCHAR));
++    url_comp.lpszUrlPath[url_comp.dwUrlPathLength + url_comp.dwExtraInfoLength] = 0;
++
++    if (!(hinternet = InternetOpenW(L"wininet", INTERNET_OPEN_TYPE_DIRECT, NULL, NULL, 0)))
++    {
++        WARN("InternetOpenW failed: %d\n", GetLastError());
++        return FALSE;
++    }
++
++    if (!(hconnect = InternetConnectW(hinternet, url_comp.lpszHostName, url_comp.nPort,
++        url_comp.lpszUserName, url_comp.lpszPassword, INTERNET_SERVICE_HTTP, 0, 0)))
++    {
++        WARN("InternetConnectW failed: %d\n", GetLastError());
++        InternetCloseHandle(hinternet);
++        return FALSE;
++    }
++
++    if (!(hrequest = HttpOpenRequestW(hconnect, L"GET", url_comp.lpszUrlPath,
++        NULL, NULL,
++        acccept_types,
++        INTERNET_FLAG_NO_CACHE_WRITE|INTERNET_FLAG_NO_COOKIES|INTERNET_FLAG_NO_UI|INTERNET_FLAG_RELOAD, 0)))
++    {
++        WARN("InternetConnectW failed: %d\n", GetLastError());
++        InternetCloseHandle(hconnect);
++        InternetCloseHandle(hinternet);
++        return FALSE;
++    }
++
++    if (!HttpSendRequestW(hrequest, NULL, 0, NULL, 0))
++    {
++        WARN("HttpSendRequestW failed: %d\n", GetLastError());
++        InternetCloseHandle(hrequest);
++        InternetCloseHandle(hconnect);
++        InternetCloseHandle(hinternet);
++        return FALSE;
++    }
++
++    if (!HttpQueryInfoW(hrequest, HTTP_QUERY_CONTENT_LENGTH, content_length, &content_length_size, NULL))
++    {
++        WARN("HttpQueryInfoW failed: %d\n", GetLastError());
++        InternetCloseHandle(hrequest);
++        InternetCloseHandle(hconnect);
++        InternetCloseHandle(hinternet);
++        return FALSE;
++    }
++
++    InternetCloseHandle(hrequest);
++    InternetCloseHandle(hconnect);
++    InternetCloseHandle(hinternet);
++
++    if (!content_length_size)
++    {
++        WARN("Content-Length could not be retrieved\n");
++        return FALSE;
++    }
++
++    size = wcstoul(content_length, NULL, 10);
++
++    if (!size)
++        return FALSE;
++
++    /* Retrieve the current running application path */
++    if (!GetModuleFileNameW(NULL, temp_buffer, temp_buffer_size))
++    {
++        WARN("GetModuleFileNameW failed: %d\n", GetLastError());
++        return FALSE;
++    }
++
++    PathCchRemoveFileSpec(temp_buffer, temp_buffer_size);
++    PathCchAppendEx(temp_buffer, temp_buffer_size, L"StandaloneWindows64_Data\\StreamingAssets\\*",
++        PATHCCH_ALLOW_LONG_PATHS);
++
++    if ((hfind = FindFirstFileExW(temp_buffer, FindExInfoBasic, &find_file_data,
++        FindExSearchNameMatch, NULL, 0)) == INVALID_HANDLE_VALUE)
++    {
++        WARN("FindFirstFileExW failed: %d\n", GetLastError());
++        return FALSE;
++    }
++
++    do
++    {
++        if (find_file_data.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY)
++            continue;
++        if (find_file_data.nFileSizeHigh > 0)
++            file_size = (find_file_data.nFileSizeHigh * (MAXDWORD+1)) + find_file_data.nFileSizeLow;
++        else
++            file_size = find_file_data.nFileSizeLow;
++        if (file_size != size)
++            continue;
++        PathCchRemoveFileSpec(temp_buffer, temp_buffer_size);
++        PathCchAppendEx(temp_buffer, temp_buffer_size, find_file_data.cFileName,
++            PATHCCH_ALLOW_LONG_PATHS);
++        FindClose(hfind);
++        return TRUE;
++    }
++    while (FindNextFileW(hfind, &find_file_data));
++    if (GetLastError() != ERROR_NO_MORE_FILES)
++    {
++        WARN("FindNextFileW failed: %d\n", GetLastError());
++    }
++    FindClose(hfind);
++
++    return FALSE;
++}
++
++/*
++ * Tests if The Good Life (1452500) workaround needs to be applied
++ * temp_buffer should be PATHCCH_MAX_CCH characters long for extended path support
++ */
++static BOOL thegoodlife_workaround_scheme_check(const WCHAR *url, WCHAR *temp_buffer, DWORD temp_buffer_size)
++{
++    if (lstrlenW(url) < 5 || memcmp(url, L"http:", sizeof(WCHAR) * 5))
++        return FALSE;
++
++    /* Retrieve the current running application path */
++    if (!GetModuleFileNameW(NULL, temp_buffer, temp_buffer_size))
++    {
++        WARN("GetModuleFileNameW failed: %d\n", GetLastError());
++        return FALSE;
++    }
++
++    PathCchRemoveFileSpec(temp_buffer, temp_buffer_size);
++    PathCchAppendEx(temp_buffer, temp_buffer_size, L"StandaloneWindows64_Data\\StreamingAssets",
++        PATHCCH_ALLOW_LONG_PATHS);
++    return PathFileExistsW(temp_buffer);
++}
++
+ static HRESULT WINAPI source_resolver_CreateObjectFromURL(IMFSourceResolver *iface, const WCHAR *url,
+         DWORD flags, IPropertyStore *props, MF_OBJECT_TYPE *obj_type, IUnknown **object)
+ {
+@@ -6262,12 +6443,27 @@ static HRESULT WINAPI source_resolver_CreateObjectFromURL(IMFSourceResolver *ifa
+     IRtwqAsyncResult *result;
+     RTWQASYNCRESULT *data;
+     HRESULT hr;
++    WCHAR tgl_workaround_buffer[PATHCCH_MAX_CCH];
+ 
+     TRACE("%p, %s, %#x, %p, %p, %p.\n", iface, debugstr_w(url), flags, props, obj_type, object);
+ 
+     if (!url || !obj_type || !object)
+         return E_POINTER;
+ 
++    if (thegoodlife_workaround_scheme_check(url, tgl_workaround_buffer, PATHCCH_MAX_CCH))
++    {
++        TRACE("Applying The Good Life (1452500) workaround to %s.\n", debugstr_w(url));
++        if (!thegoodlife_workaround_url_matcher(url, tgl_workaround_buffer, PATHCCH_MAX_CCH))
++        {
++            WARN("Applying The Good Life (1452500) workaround to %s failed.\n", debugstr_w(url));
++        }
++        else
++        {
++            url = tgl_workaround_buffer;
++            TRACE("%p, %s, %#x, %p, %p, %p.\n", iface, debugstr_w(url), flags, props, obj_type, object);
++        }
++    }
++
+     if (FAILED(hr = resolver_get_scheme_handler(url, flags, &handler)))
+         return hr;
+ 
+@@ -6303,12 +6499,27 @@ static HRESULT WINAPI source_resolver_CreateObjectFromByteStream(IMFSourceResolv
+     IRtwqAsyncResult *result;
+     RTWQASYNCRESULT *data;
+     HRESULT hr;
++    WCHAR tgl_workaround_buffer[PATHCCH_MAX_CCH];
+ 
+     TRACE("%p, %p, %s, %#x, %p, %p, %p.\n", iface, stream, debugstr_w(url), flags, props, obj_type, object);
+ 
+     if (!stream || !obj_type || !object)
+         return E_POINTER;
+ 
++    if (thegoodlife_workaround_scheme_check(url, tgl_workaround_buffer, PATHCCH_MAX_CCH))
++    {
++        TRACE("Applying The Good Life (1452500) workaround to %s.\n", debugstr_w(url));
++        if (!thegoodlife_workaround_url_matcher(url, tgl_workaround_buffer, PATHCCH_MAX_CCH))
++        {
++            WARN("Applying The Good Life (1452500) workaround to %s failed.\n", debugstr_w(url));
++        }
++        else
++        {
++            url = tgl_workaround_buffer;
++            TRACE("%p, %p, %s, %#x, %p, %p, %p.\n", iface, stream, debugstr_w(url), flags, props, obj_type, object);
++        }
++    }
++
+     if (FAILED(hr = resolver_get_bytestream_handler(stream, url, flags, &handler)))
+         return MF_E_UNSUPPORTED_BYTESTREAM_TYPE;
+ 
+@@ -6344,9 +6555,24 @@ static HRESULT WINAPI source_resolver_BeginCreateObjectFromURL(IMFSourceResolver
+     IUnknown *inner_cookie = NULL;
+     IRtwqAsyncResult *result;
+     HRESULT hr;
++    WCHAR tgl_workaround_buffer[PATHCCH_MAX_CCH];
+ 
+     TRACE("%p, %s, %#x, %p, %p, %p, %p.\n", iface, debugstr_w(url), flags, props, cancel_cookie, callback, state);
+ 
++    if (thegoodlife_workaround_scheme_check(url, tgl_workaround_buffer, PATHCCH_MAX_CCH))
++    {
++        TRACE("Applying The Good Life (1452500) workaround to %s.\n", debugstr_w(url));
++        if (!thegoodlife_workaround_url_matcher(url, tgl_workaround_buffer, PATHCCH_MAX_CCH))
++        {
++            WARN("Applying The Good Life (1452500) workaround to %s failed.\n", debugstr_w(url));
++        }
++        else
++        {
++            url = tgl_workaround_buffer;
++            TRACE("%p, %s, %#x, %p, %p, %p, %p.\n", iface, debugstr_w(url), flags, props, cancel_cookie, callback, state);
++        }
++    }
++
+     if (FAILED(hr = resolver_get_scheme_handler(url, flags, &handler)))
+         return hr;
+ 
+-- 
+2.33.1
+

--- a/patches/protonprep.sh
+++ b/patches/protonprep.sh
@@ -145,6 +145,10 @@
     echo "killer instinct vulkan fix"
     patch -Np1 < ../patches/game-patches/killer-instinct-winevulkan_fix.patch
 
+    # missing http: scheme workaround see: https://github.com/ValveSoftware/Proton/issues/5195
+    echo "The Good Life (1452500) workaround"
+    patch -Np1 < ../patches/game-patches/thegoodlife-mfplat-http-scheme-workaround.patch
+
 ### END GAME PATCH SECTION ###
 
 ### (2-4) PROTON PATCH SECTION ###


### PR DESCRIPTION
Workaround for [The Good Life (1452500)](https://store.steampowered.com/app/1452500/The_Good_Life/).

This adds a patch against mfplat that works around the missing `http:` scheme support by matching the right files using the Content-Length response header. The devs for some reason serve their own video files over their own builtin http server with randomly generated url paths (e.g.: `http://localhost:16700/scKuNR_abc-ylAi3WwBng_X7xyVI1nLb`).

See: https://github.com/ValveSoftware/Proton/issues/5195

I'll also mention that it came to light during the discussion that having the game installed on a steam library folder that isn't the primary one, results in getting stuck. The url replacement and the opening of the file using the `file:` scheme seems to be successful though, so it looks like something is amiss during the decoding phase related to cross device steam library folders.