### PR TITLE
Fix the Vagrantfile so that we use up to date packages.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -68,7 +68,7 @@ Vagrant.configure(2) do |config|
       set -e
       #install docker and steam-runtime dependencies
       dpkg --add-architecture i386
-      apt-get update
+      apt-get update && apt-get --assume-yes upgrade
       apt-get install -y apt-transport-https ca-certificates curl gnupg2 software-properties-common
 
       #add docker repo

--- a/Vagrantfile.github
+++ b/Vagrantfile.github
@@ -70,7 +70,7 @@ Vagrant.configure(2) do |config|
     debian10.vm.provision "shell", privileged: "true", inline: <<-SHELL
       #install docker and steam-runtime dependencies
       dpkg --add-architecture i386
-      apt-get update
+      apt-get update && apt-get --assume-yes upgrade
       apt-get install -y apt-transport-https ca-certificates curl gnupg2 software-properties-common
 
       #add docker repo


### PR DESCRIPTION
Apparently we never run a `apt-get upgrade` after the `apt-get update`, so we end up using old versions of packages. In particular, we end up using an old version of make which doesn't like multiple target declarations. This hopefully should fix the `Makefile:108: *** multiple target patterns.  Stop.` in Github Actions and local builds.