### PR TITLE
Update README.md - include a working path

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ PLEASE NOTE: There are prerequisites for using this version of proton:
 This section is for those that use the native version of Steam.
 
 1. Download a release from the [Releases](https://github.com/GloriousEggroll/proton-ge-custom/releases) page.
-2. Create a `~/.steam/root/compatibilitytools.d` directory if it does not exist.
+2. Create a `~/.steam/root/compatibilitytools.d` directory if it does not exist. (If this path doesn't make Steam detect Proton-GE on debian based distros, try this path instead: `~/.steam/steam/compatibilitytools.d/`.
 3. Extract the release tarball into `~/.steam/root/compatibilitytools.d/`.
    * `tar -xf Proton-VERSION.tar.gz -C ~/.steam/root/compatibilitytools.d/`
 4. Restart Steam.


### PR DESCRIPTION
I tried every path listed here but nothing worked in my case, except when a user on discord [advised me](https://discord.com/channels/110175050006577152/476776276158316556/925196587393761291) to use the path `~/.steam/steam/compatibilitytools.d/`. That immediately worked, and issues are disabled on your repo, so i am making this pull request where i'm including additional info in case the main path doesn't work.

i use Pop!OS 21.10 with .deb installation of Steam.