### PR TITLE
Enable h264 and aac decoders required by Borderlands 3

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -590,7 +590,9 @@ FFMPEG_CONFIGURE_ARGS := \
 	--enable-decoder=wmav1 \
 	--enable-decoder=wmv3 \
 	--enable-decoder=wmv2 \
-	--enable-decoder=wmv1
+	--enable-decoder=wmv1 \
+	--enable-decoder=h264 \
+	--enable-decoder=aac
 
 $(eval $(call rules-source,ffmpeg,$(SRCDIR)/FFmpeg))
 $(eval $(call rules-configure,ffmpeg,32))


### PR DESCRIPTION
After switching to Valve's wine and changing ffmpeg, h264 is no longer being included.
Borderlands 3 requires h264/aac. Just adding it to ffmpeg.