### PR TITLE
Add gamemode client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@
 
 /.vagrant/
 /vagrant_share/
+build/*
+contrib/*

--- a/.gitmodules
+++ b/.gitmodules
@@ -70,3 +70,6 @@
 [submodule "gst-plugins-rs"]
 	path = gst-plugins-rs
 	url = https://gitlab.freedesktop.org/gstreamer/gst-plugins-rs.git
+[submodule "gamemode"]
+	path = gamemode
+	url = https://github.com/FeralInteractive/gamemode

--- a/Makefile.in
+++ b/Makefile.in
@@ -418,6 +418,25 @@ module: module32 module64
 
 endif # ifeq ($(CONTAINER),)
 
+##
+## gamemode
+##
+
+GAMEMODE_MESON_ARGS = \
+	-Dwith-sd-bus-provider=no-daemon \
+	-Dwith-util=false \
+
+$(eval $(call rules-source,gamemode,$(SRCDIR)/gamemode))
+$(eval $(call rules-meson,gamemode,32))
+$(eval $(call rules-meson,gamemode,64))
+
+$(OBJ)/.gamemode-post-build32:
+	mkdir -p $(DST_DIR)/bin
+	cp -f $(SRCDIR)/gamemode/data/gamemoderun $(DST_DIR)/bin
+
+$(OBJ)/.gamemode-post-build64:
+	mkdir -p $(DST_DIR)/bin
+	cp -f $(SRCDIR)/gamemode/data/gamemoderun $(DST_DIR)/bin
 
 ##
 ## dav1d

--- a/proton
+++ b/proton
@@ -353,6 +353,7 @@ class Proton:
         self.version_file = self.path("version")
         self.default_pfx_dir = self.path("files/share/default_pfx/")
         self.user_settings_file = self.path("user_settings.py")
+        self.gamemoderun = self.bin_dir + "gamemoderun"
         self.wine_bin = self.bin_dir + "wine"
         self.wine64_bin = self.bin_dir + "wine64"
         self.wineserver_bin = self.bin_dir + "wineserver"
@@ -1560,9 +1561,9 @@ class Session:
 
         # CoD: Black Ops 3 workaround
         if os.environ.get("SteamGameId", 0) == "311210":
-            rc = self.run_proc([g_proton.wine_bin, "c:\\Program Files (x86)\\Steam\\steam.exe"] + sys.argv[2:] + self.cmdlineappend)
+            rc = self.run_proc([g_proton.gamemoderun, g_proton.wine_bin, "c:\\Program Files (x86)\\Steam\\steam.exe"] + sys.argv[2:] + self.cmdlineappend)
         else:
-            rc = self.run_proc([g_proton.wine64_bin, "c:\\windows\\system32\\steam.exe"] + sys.argv[2:] + self.cmdlineappend)
+            rc = self.run_proc([g_proton.gamemoderun, g_proton.wine64_bin, "c:\\windows\\system32\\steam.exe"] + sys.argv[2:] + self.cmdlineappend)
 
         if remote_debug_proc:
             remote_debug_proc.kill()


### PR DESCRIPTION
This add Feral's Gamemode client on the boot of the game so the process will boot with priority, in case that the computer doesn't have the Gamemode installed it will boot the game either way but with this modication off.
So from now on "gamemoderun %command%" won't be needed anymore

Related to https://github.com/ValveSoftware/Proton/issues/622