### PR TITLE
Fix missing tracked_files for apps with protonfixes

### DIFF
--- a/proton
+++ b/proton
@@ -1654,9 +1654,9 @@ if __name__ == "__main__":
     if g_proton.missing_default_prefix():
         g_proton.make_default_prefix()
 
-    import protonfixes
-
     g_session.init_session(sys.argv[1] != "runinprefix")
+
+    import protonfixes
 
     #determine mode
     rc = 0


### PR DESCRIPTION
Executing protonfixes that contains winetricks prior init_session will
interfere with init_session internal checks during prefix update in
setup_prefix function.

This will lead to copy_pfx not being called because user.reg file will
already exists due to winetricks writing registry stuff.

Since tracked_files is created during copy_pfx, that will ultimately
lead to a crash in update_builtin_libs because tracked_files were
never created.