### PR TITLE
Fix "FileNotFoundError"

### DIFF
--- a/proton
+++ b/proton
@@ -785,7 +785,9 @@ class CompatData:
                 self.copy_pfx()
 
             self.migrate_user_paths()
-
+            
+            makedirs(self.prefix_dir + "/dosdevices/")
+            
             if not file_exists(self.prefix_dir + "/dosdevices/c:", follow_symlinks=False):
                 os.symlink("../drive_c", self.prefix_dir + "/dosdevices/c:")
 


### PR DESCRIPTION
![image_2022-07-17_11-51-52](https://user-images.githubusercontent.com/92713267/179391758-ded7888b-0c9d-4de0-800d-6298fe186c4e.png)

Every time I try to run a prefix that has not been run before with proton-ge, I get an exception and the game does not start. This line fixes the problem.

I don't know where this regression came from, but it appeared a long time ago, and I finally got around to dealing with it. I do not know "dosdevices" is a modification of proton-ge or it was in the original proton, but now it is not there.