### PR TITLE
Import Saints Row 2022 fix from upstream

### DIFF
--- a/patches/protonprep-valve-staging.sh
+++ b/patches/protonprep-valve-staging.sh
@@ -373,6 +373,9 @@
     
     echo "WINE: -HOTFIX- fix Visual Novel Doukyuusei"
     patch -Np1 < ../patches/wine-hotfixes/upstream/visual-novel-doukyuusei.patch
+
+    echo "WINE: -HOTFIX- fix Saints Row 2022"
+    patch -Np1 < ../patches/wine-hotfixes/upstream/saintsrow.patch
     
 ### END WINE HOTFIX SECTION ###
 

--- a/patches/wine-hotfixes/upstream/saintsrow.patch
+++ b/patches/wine-hotfixes/upstream/saintsrow.patch
@@ -1,5 +1,17 @@
+From a9ed113347eea3ad60f95b4c1fe16a9254192384 Mon Sep 17 00:00:00 2001
+From: Gijs Vermeulen <gijsvrm@gmail.com>
+Date: Thu, 25 Aug 2022 14:45:13 +0200
+Subject: [PATCH] kernel32: Add SetProcessDefaultCpuSets stub.
+
+Wine-Bug: https://bugs.winehq.org/show_bug.cgi?id=53589
+---
+ dlls/kernel32/kernel32.spec     |  1 +
+ dlls/kernelbase/kernelbase.spec |  2 +-
+ dlls/kernelbase/memory.c        | 11 +++++++++++
+ 3 files changed, 13 insertions(+), 1 deletion(-)
+
 diff --git a/dlls/kernel32/kernel32.spec b/dlls/kernel32/kernel32.spec
-index a5fa757da9fdbaa6e6e3462d797a5de3643e4bf7..7c5fb8ed74f18c26a94f4798487c8f5d7c89ca23 100644
+index a5fa757da9f..7c5fb8ed74f 100644
 --- a/dlls/kernel32/kernel32.spec
 +++ b/dlls/kernel32/kernel32.spec
 @@ -1444,6 +1444,7 @@
@@ -11,7 +23,7 @@ index a5fa757da9fdbaa6e6e3462d797a5de3643e4bf7..7c5fb8ed74f18c26a94f4798487c8f5d
  @ stdcall -import SetProcessMitigationPolicy(long ptr long)
  @ stdcall -import SetProcessPreferredUILanguages(long ptr ptr)
 diff --git a/dlls/kernelbase/kernelbase.spec b/dlls/kernelbase/kernelbase.spec
-index 1296757b29aee3169bb8a1f8591857a6d6a9a909..feb1fce8f7aa0e1d96e69d97345eb009c784797f 100644
+index 1296757b29a..feb1fce8f7a 100644
 --- a/dlls/kernelbase/kernelbase.spec
 +++ b/dlls/kernelbase/kernelbase.spec
 @@ -1490,7 +1490,7 @@
@@ -24,13 +36,13 @@ index 1296757b29aee3169bb8a1f8591857a6d6a9a909..feb1fce8f7aa0e1d96e69d97345eb009
  # @ stub SetProcessInformation
  @ stdcall SetProcessMitigationPolicy(long ptr long)
 diff --git a/dlls/kernelbase/memory.c b/dlls/kernelbase/memory.c
-index 2418c67055787e6f1558675c6d159aeb19f2b922..14d8c4817a582dff606890357a0777ec64111034 100644
+index 2418c670557..14d8c4817a5 100644
 --- a/dlls/kernelbase/memory.c
 +++ b/dlls/kernelbase/memory.c
 @@ -1336,6 +1336,17 @@ BOOL WINAPI SetThreadSelectedCpuSets(HANDLE thread, const ULONG *cpu_set_ids, UL
  }
- 
- 
+
+
 +/***********************************************************************
 + *           SetProcessDefaultCpuSets   (kernelbase.@)
 + */

--- a/patches/wine-hotfixes/upstream/saintsrow.patch
+++ b/patches/wine-hotfixes/upstream/saintsrow.patch
@@ -1,0 +1,47 @@
+diff --git a/dlls/kernel32/kernel32.spec b/dlls/kernel32/kernel32.spec
+index a5fa757da9fdbaa6e6e3462d797a5de3643e4bf7..7c5fb8ed74f18c26a94f4798487c8f5d7c89ca23 100644
+--- a/dlls/kernel32/kernel32.spec
++++ b/dlls/kernel32/kernel32.spec
+@@ -1444,6 +1444,7 @@
+ @ stdcall -import SetPriorityClass(long long)
+ @ stdcall SetProcessAffinityMask(long long)
+ @ stdcall -import SetProcessAffinityUpdateMode(long long)
++@ stdcall -import SetProcessDefaultCpuSets(ptr ptr long)
+ @ stdcall SetProcessDEPPolicy(long)
+ @ stdcall -import SetProcessMitigationPolicy(long ptr long)
+ @ stdcall -import SetProcessPreferredUILanguages(long ptr ptr)
+diff --git a/dlls/kernelbase/kernelbase.spec b/dlls/kernelbase/kernelbase.spec
+index 1296757b29aee3169bb8a1f8591857a6d6a9a909..feb1fce8f7aa0e1d96e69d97345eb009c784797f 100644
+--- a/dlls/kernelbase/kernelbase.spec
++++ b/dlls/kernelbase/kernelbase.spec
+@@ -1490,7 +1490,7 @@
+ @ stdcall SetPrivateObjectSecurity(long ptr ptr ptr long)
+ @ stdcall SetPrivateObjectSecurityEx(long ptr ptr long ptr long)
+ @ stdcall SetProcessAffinityUpdateMode(long long)
+-# @ stub SetProcessDefaultCpuSets
++@ stdcall SetProcessDefaultCpuSets(ptr ptr long)
+ @ stdcall SetProcessGroupAffinity(long ptr ptr)
+ # @ stub SetProcessInformation
+ @ stdcall SetProcessMitigationPolicy(long ptr long)
+diff --git a/dlls/kernelbase/memory.c b/dlls/kernelbase/memory.c
+index 2418c67055787e6f1558675c6d159aeb19f2b922..14d8c4817a582dff606890357a0777ec64111034 100644
+--- a/dlls/kernelbase/memory.c
++++ b/dlls/kernelbase/memory.c
+@@ -1336,6 +1336,17 @@ BOOL WINAPI SetThreadSelectedCpuSets(HANDLE thread, const ULONG *cpu_set_ids, UL
+ }
+ 
+ 
++/***********************************************************************
++ *           SetProcessDefaultCpuSets   (kernelbase.@)
++ */
++BOOL WINAPI SetProcessDefaultCpuSets(HANDLE process, const ULONG *cpu_set_ids, ULONG count)
++{
++    FIXME( "process %p, cpu_set_ids %p, count %lu stub.\n", process, cpu_set_ids, count );
++
++    return TRUE;
++}
++
++
+ /**********************************************************************
+  *             GetNumaHighestNodeNumber   (kernelbase.@)
+  */


### PR DESCRIPTION
I haven't tested this, but it compiles successfully and the patch was applied
edit: this should be in wine-ge, that's my bad
edit2: tested working, using LoadLibrary