### PR TITLE
Fix redist dir being moved inside $(BUILD_NAME)

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -399,6 +399,7 @@ redist: dist | $(filter-out dist deploy install redist,$(MAKECMDGOALS))
 	cp $(PROTONFIXES_TARGET)/cabextract $(REDIST_DIR)/files/bin/
 	cp $(PROTONFIXES_TARGET)/libmspack.so.0 $(REDIST_DIR)/files/lib64/
 	cp $(PROTONFIXES_TARGET)/libmspack.so.0.1.0 $(REDIST_DIR)/files/lib64/
+	rm -rf $(BUILD_NAME)
 	mv $(REDIST_DIR) $(BUILD_NAME)
 	tar -cvzf $(BUILD_NAME).tar.gz $(BUILD_NAME)
 	sha512sum $(BUILD_NAME).tar.gz > $(BUILD_NAME).sha512sum


### PR DESCRIPTION
When I rebuild proton I noticed that the new build is placed inside the existing build directory as `redist`.
The problem is that `mv $(REDIST_DIR) $(BUILD_NAME)` will move redist inside the build directory if it already exists instead of overwriting it.