### PR TITLE
Add PROTON_USE_WINED3D9

### DIFF
--- a/proton
+++ b/proton
@@ -1472,7 +1472,8 @@ class Session:
             self.compat_config.add("wined3d")
 
         if not self.check_environment("PROTON_USE_WINED3D", "wined3d"):
-            self.check_environment("PROTON_USE_WINED3D11", "wined3d")
+            if not self.check_environment("PROTON_USE_WINED3D11", "wined3d"):
+                self.check_environment("PROTON_USE_WINED3D9",  "wined3d9")
         self.check_environment("PROTON_NO_D3D12", "nod3d12")
         self.check_environment("PROTON_NO_D3D11", "nod3d11")
         self.check_environment("PROTON_NO_D3D10", "nod3d10")
@@ -1604,6 +1605,9 @@ class Session:
         if "nod3d9" in self.compat_config:
             self.dlloverrides["d3d9"] = ""
             self.dlloverrides["dxgi"] = ""
+
+        if "wined3d9" in self.compat_config:
+            self.dlloverrides["d3d9"] = "b"
 
         if "enablenvapi" in self.compat_config:
             self.env["DXVK_ENABLE_NVAPI"] = "1"


### PR DESCRIPTION
An environment variable that forces use of wine's builtin d3d9, while keeping dxvk for d3d10+. The use case for me is with Secret World Lengends. The game itself has a d3d11 mode that works great with dxvk (hence I don't want PROTON_USE_WINED3D), but the patcher, a d3d9 app, breaks with dxvk but works with wined3d. Just setting WINEDLLOVERRIDES=d3d9=b doesn't work since proton will add a d3d9=n to the end of WINEDLLOVERRIDES if dxvk is used, thus overriding it.

A protonfix will also work, and I'll submit a pull request for that as well, but having a PROTON_USE_WINED3D9 gives the ability to perform the override without needing to dig into protontricks, ie. for testing (and apps with similar problems).