### PR TITLE
Fixes Anno's 1800 broken multiplayer, allows players to join lobbies …

### DIFF
--- a/patches/game-patches/Anno-1800-Multiplayer_fix.patch
+++ b/patches/game-patches/Anno-1800-Multiplayer_fix.patch
@@ -1,0 +1,38 @@
+From 0a62ca19414ac1af6fde01f417f18d5a9ecbef54 Mon Sep 17 00:00:00 2001
+From: Fabian Druschke <fabian@knogle.industries>
+Date: Tue, 3 Jan 2023 13:46:25 +0100
+Subject: [PATCH] Enhance Anno 1800 multiplayer compatbility, added ECDH_P384
+ handling
+
+---
+ dlls/bcrypt/bcrypt_main.c | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/dlls/bcrypt/bcrypt_main.c b/dlls/bcrypt/bcrypt_main.c
+index eef0443c91f..9bc2b9050b4 100644
+--- a/dlls/bcrypt/bcrypt_main.c
++++ b/dlls/bcrypt/bcrypt_main.c
+@@ -1452,6 +1452,10 @@ static NTSTATUS key_import_pair( struct algorithm *alg, const WCHAR *type, BCRYP
+             key_size = 32;
+             magic = BCRYPT_ECDH_PRIVATE_P256_MAGIC;
+             break;
++	case ALG_ID_ECDH_P384:
++            key_size = 48;
++            magic = BCRYPT_ECDH_PRIVATE_P384_MAGIC;
++            break;
+         case ALG_ID_ECDSA_P256:
+             key_size = 32;
+             magic = BCRYPT_ECDSA_PRIVATE_P256_MAGIC;
+@@ -1707,6 +1711,7 @@ NTSTATUS WINAPI BCryptGenerateKeyPair( BCRYPT_ALG_HANDLE algorithm, BCRYPT_KEY_H
+     switch (alg->id)
+     {
+     case ALG_ID_ECDH_P256:
++    case ALG_ID_ECDH_P384:
+     case ALG_ID_ECDSA_P256:
+         size = sizeof(BCRYPT_ECCKEY_BLOB) + 2 * 256 / 8;
+         break;
+
+base-commit: 492470267af486cb24ad0deaa028168eb94618a4
+-- 
+2.39.2
+

--- a/patches/protonprep-valve-staging.sh
+++ b/patches/protonprep-valve-staging.sh
@@ -326,6 +326,9 @@
     echo "WINE: -GAME FIXES- add file search workaround hack for Phantasy Star Online 2"
     patch -Np1 < ../patches/game-patches/pso2_hack.patch
 
+    echo "WINE: -GAME FIXES- Enhance Anno 1800 multiplayer compatbility, added ECDH_P384 handling"
+    patch -Np1 < ../patches/game-patches/Anno-1800-Multiplayer_fix.patch
+
 ### END GAME PATCH SECTION ###
 
 ### (2-4) PROTON PATCH SECTION ###


### PR DESCRIPTION
…and play now.

Due to missing case handling for ECDH_P384 during the joining handshakes for multiplayer it's not possible to join a friend's game without this fix. It's interesting for Proton due to Ubisoft games being available on Steam again, but may also be of interest for wine-ge-custom. 
This fix has been comitted already, https://github.com/ValveSoftware/wine/pull/173 but may take months or years to go upstream.
