### PR TITLE
Add instructions for installing with Steam Snap

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,20 @@ This unofficial build isn't supported by GloriousEggroll nor Valve and wasn't te
 4. Restart Steam.
 5. [Enable proton-ge-custom](#enabling).
 
+#### Snap
+
+This section is for those that use the Steam [snap](https://snapcraft.io/steam).
+
+This unofficial build isn't supported by GloriousEggroll nor Valve and wasn't tested with all possible games and cases. It can behave differently from upstream builds. Use at your own risk.
+
+##### Manual
+
+1. Download a release from the [Releases](https://github.com/GloriousEggroll/proton-ge-custom/releases) page.
+2. Create a `~/snap/steam/common/.steam/steam/compatibilitytools.d/` directory if it does not exist.
+3. Extract the release tarball into `~/snap/steam/common/.steam/steam/compatibilitytools.d/`.
+   * `tar -xf GE-ProtonVERSION.tar.gz -C ~/snap/steam/common/.steam/steam/compatibilitytools.d/`
+4. Restart Steam.
+5. [Enable proton-ge-custom](#enabling).
 
 ## Building
 


### PR DESCRIPTION
Canonical released a Steam snap recently and it's really good so you might see some people switching to it and wondering how to install GE.

This just adds some instructions to save people looking for the right directory, it's essentially the same as the AppImage manual install and I've copy-pasted most of the text.