### PR TITLE
reference to flatpak build repo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ This section is for those that use the Steam flatpak.
 
 ##### Flathub
 
-This unofficial build isn't supported by GloriousEggroll nor Valve and wasn't tested with all possible games and cases. It can behave differently from upstream builds. Use at your own risk.
+[The unofficial build provided by Flathub](https://github.com/flathub/com.valvesoftware.Steam.CompatibilityTool.Proton-GE) isn't supported by GloriousEggroll nor Valve and wasn't tested with all possible games and cases. It can behave differently from upstream builds. Use at your own risk.
 
 1. [Add the Flathub repository](https://flatpak.org/setup/).
 2. Run:


### PR DESCRIPTION
This is not a shameless plug I swear, I just happened to be looking for the repository like five times and struggled to find the correct link every single time.
Having this in the readme will save me about as much time as I spent on writing this PR within the next five years.

[![xkcd 1205: Automation](https://imgs.xkcd.com/comics/is_it_worth_the_time.png)](https://xkcd.com/1205/)