### PR TITLE
README.md: Improve bash commands and add a script option

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,14 +97,14 @@ This section is for those that use the native version of Steam.
 mkdir /tmp/proton-ge-custom
 cd /tmp/proton-ge-custom
 
-# download  tarball 
-curl -sLOJ $(curl -s https://api.github.com/repos/GloriousEggroll/proton-ge-custom/releases/latest | grep browser_download_url | cut -d\" -f4 | egrep .tar.gz)
+# download  tarball
+curl -sLOJ "$(curl -s https://api.github.com/repos/GloriousEggroll/proton-ge-custom/releases/latest | grep browser_download_url | cut -d\" -f4 | grep .tar.gz)"
 
-# download checksum 
-curl -sLOJ $(curl -s https://api.github.com/repos/GloriousEggroll/proton-ge-custom/releases/latest | grep browser_download_url | cut -d\" -f4 | egrep .sha512sum) 
+# download checksum
+curl -sLOJ "$(curl -s https://api.github.com/repos/GloriousEggroll/proton-ge-custom/releases/latest | grep browser_download_url | cut -d\" -f4 | grep .sha512sum)"
 
 # check tarball with checksum
-sha512sum -c *.sha512sum
+sha512sum -c ./*.sha512sum
 # if result is ok, continue
 
 # make steam directory if it does not exist
@@ -113,6 +113,17 @@ mkdir -p ~/.steam/root/compatibilitytools.d
 # extract proton tarball to steam directory
 tar -xf GE-Proton*.tar.gz -C ~/.steam/root/compatibilitytools.d/
 echo "All done :)"
+```
+
+The shell code above can be run as a script by pasting the commands in a file and adding the following to the top of the file:
+```bash
+#!/bin/bash
+set -euo pipefail
+```
+
+Save the file and make the script runnable by adding the executable bit:
+```bash
+chmod +x file.sh
 ```
 
 #### Flatpak


### PR DESCRIPTION
This PR improves the bash commands in the manual/native installation section. This commit contains the following changes:

- Add instructions to run the commands as a script
- Quote subshell to prevent word splitting: [SC2046](https://www.shellcheck.net/wiki/SC2046)
- Add safe glob expansion for the sha512sum command: [SC2035](https://www.shellcheck.net/wiki/SC2035)
- Replace 'egrep' with POSIX compliant 'grep': [SC196](https://www.shellcheck.net/wiki/SC2196)
   ('grep -E' is omitted due to it not being needed)