### PR TITLE
patches: add yakuza 5 cutscenes audio fix

### DIFF
--- a/patches/game-patches/yakuza5-cutscenes.patch
+++ b/patches/game-patches/yakuza5-cutscenes.patch
@@ -1,0 +1,53 @@
+diff --git a/dlls/ntdll/unix/file.c b/dlls/ntdll/unix/file.c
+index 7955a88b622..12cdcecfe30 100644
+--- a/dlls/ntdll/unix/file.c
++++ b/dlls/ntdll/unix/file.c
+@@ -241,6 +241,8 @@ static unsigned int dir_data_cache_size;
+ static BOOL show_dot_files;
+ static mode_t start_umask;
+ 
++static BOOL disable_8dot3_filename;
++
+ /* at some point we may want to allow Winelib apps to set this */
+ static const BOOL is_case_sensitive = FALSE;
+ 
+@@ -1511,16 +1513,23 @@ static BOOL append_entry( struct dir_data *data, const char *long_name,
+     if (long_len == ARRAY_SIZE(long_nameW)) return TRUE;
+     long_nameW[long_len] = 0;
+ 
+-    if (short_name)
++    if (!disable_8dot3_filename)
+     {
+-        short_len = ntdll_umbstowcs( short_name, strlen(short_name),
+-                                     short_nameW, ARRAY_SIZE( short_nameW ) - 1 );
++        if (short_name)
++        {
++            short_len = ntdll_umbstowcs( short_name, strlen(short_name),
++                                        short_nameW, ARRAY_SIZE( short_nameW ) - 1 );
++        }
++        else  /* generate a short name if necessary */
++        {
++            short_len = 0;
++            if (!is_legal_8dot3_name( long_nameW, long_len ))
++                short_len = hash_short_file_name( long_nameW, long_len, short_nameW );
++        }
+     }
+-    else  /* generate a short name if necessary */
++    else
+     {
+         short_len = 0;
+-        if (!is_legal_8dot3_name( long_nameW, long_len ))
+-            short_len = hash_short_file_name( long_nameW, long_len, short_nameW );
+     }
+     short_nameW[short_len] = 0;
+     wcsupr( short_nameW );
+@@ -3061,6 +3070,9 @@ void init_files(void)
+         }
+         NtClose( key );
+     }
++
++    const char *sgi = getenv("SteamGameId");
++    disable_8dot3_filename = sgi && !strcmp(sgi, "1105510");
+ }
+ 
+ 

--- a/patches/protonprep-valve-staging.sh
+++ b/patches/protonprep-valve-staging.sh
@@ -327,6 +327,10 @@
     echo "WINE: -GAME FIXES- Fix Farlight 84 dxva crash"
     patch -Np1 < ../patches/game-patches/farlight84.patch
 
+    # https://github.com/ValveSoftware/Proton/issues/4625
+    echo "WINE: -GAME FIXES- Fix Yakuza 5 cutscenes audio"
+    patch -Np1 < ../patches/game-patches/yakuza5-cutscenes.patch
+
 ### END GAME PATCH SECTION ###
 
 ### (2-4) WINE HOTFIX/BACKPORT SECTION ###


### PR DESCRIPTION
Disabling the generation of new short names fixes the cutscenes audio.