### PR TITLE
Fix Github Actions workflow

### DIFF
--- a/.github/patches/0001-strip-binaries-early.patch
+++ b/.github/patches/0001-strip-binaries-early.patch
@@ -1,0 +1,13 @@
+diff --git a/Makefile.in b/Makefile.in
+index 256acc2b..ece080f0 100644
+--- a/Makefile.in
++++ b/Makefile.in
+@@ -53,7 +53,7 @@ CROSSLDFLAGS   += -Wl,--file-alignment,4096
+ OPTIMIZE_FLAGS := -O2 -march=nocona -mtune=core-avx2 -mfpmath=sse
+ SANITY_FLAGS   := -fwrapv -fno-strict-aliasing
+ DEBUG_FLAGS    := -ggdb -ffunction-sections -fdata-sections -fno-omit-frame-pointer
+-COMMON_FLAGS    = $(DEBUG_FLAGS) $(OPTIMIZE_FLAGS) $(SANITY_FLAGS) -ffile-prefix-map=$(CCACHE_BASEDIR)=.
++COMMON_FLAGS    = -s $(OPTIMIZE_FLAGS) $(SANITY_FLAGS) -ffile-prefix-map=$(CCACHE_BASEDIR)=.
+ COMMON_FLAGS32 := -mstackrealign
+ COMMON_FLAGS64 := -mcmodel=small
+ CARGO_BUILD_ARGS += --release

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,59 @@
+name: Build
+
+on:
+  workflow_call:
+    inputs:
+      name:
+        required: true
+        type: string
+
+jobs:
+  proton:
+    name: ${{ inputs.name }}
+    runs-on: ubuntu-latest
+    steps:
+    - name: Prepare host
+      run: sudo apt update && sudo apt-get install -y ccache fontforge-nox
+
+    - name: Download cache
+      uses: actions/cache@v3
+      with:
+        path: ~/.ccache
+        key: ccache-proton-${{ github.run_id }}
+        restore-keys: |
+          ccache-proton
+
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+        fetch-tags: true
+        submodules: recursive
+
+    - name: Patch
+      run: |
+        # strip binaries at compile time to save space in the runner
+        patch -Np1 -i ./.github/patches/0001-strip-binaries-early.patch
+        # apply proton-ge-custom patches
+        ./patches/protonprep-valve-staging.sh || true
+        mkdir ./build
+
+    - name: Configure
+      working-directory: ./build
+      run: ../configure.sh --build-name=${{ inputs.name }} --enable-ccache --container-engine=docker
+
+    - name: Make ${{ inputs.name }}
+      working-directory: ./build
+      run: make -j3 redist
+
+    - name: Upload artifact ${{ inputs.name }}.tar.gz
+      uses: actions/upload-artifact@v3
+      with:
+        name: ${{ inputs.name }}.tar.gz
+        path: ./build/${{ inputs.name }}.tar.gz
+
+    - name: Upload artifact ${{ inputs.name }}.sha512sum
+      uses: actions/upload-artifact@v3
+      with:
+        name: ${{ inputs.name }}.sha512sum
+        path: ./build/${{ inputs.name }}.sha512sum

--- a/.github/workflows/devel.yml
+++ b/.github/workflows/devel.yml
@@ -1,0 +1,41 @@
+name: Development
+
+on:
+  workflow_dispatch:
+
+jobs:
+  version:
+    name: Version
+    runs-on: ubuntu-latest
+    outputs:
+      tag_abbrev: ${{ steps.version.outputs.tag_abbrev }}
+      tag_offset: ${{ steps.version.outputs.tag_offset }}
+      sha_short: ${{ steps.version.outputs.sha_short }}
+      full_desc: ${{ steps.version.outputs.full_desc }}
+      branch: ${{ steps.version.outputs.branch }}
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+        fetch-tags: true
+
+    - name: Version
+      id: version
+      shell: bash
+      run: |
+        tag_abbrev=$(git describe --tags --abbrev=0)
+        echo "tag_abbrev=$tag_abbrev" >> $GITHUB_OUTPUT
+        echo "tag_offset=$(git rev-list $tag_abbrev..HEAD --count)" >> $GITHUB_OUTPUT
+        echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+        echo "full_desc=$(git describe --long --tags)" >> $GITHUB_OUTPUT
+        echo "branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_OUTPUT
+
+  build:
+    needs: version
+    name: Build
+    uses: ./.github/workflows/build.yml
+    with:
+      name: ${{ needs.version.outputs.full_desc }}-${{ needs.version.outputs.branch }}
+
+

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,71 +1,43 @@
+name: Release
+
 on:
-  workflow_dispatch:
+  release:
+    types: [ published ]
 
 jobs:
-  build-proton-ge:
+  build:
+    name: Build
+    uses: ./.github/workflows/build.yml
+    with:
+      name: ${{ github.ref_name }}
+
+  release:
+    name: Release ${{ github.ref_name }}
+    needs: build
     runs-on: ubuntu-latest
     steps:
-    
-      - name: Get branch names
-        id: branch-name
-        uses: tj-actions/branch-names@v5.1
-    
-      - name: Clone repo
-        run: git clone -b ${{ steps.branch-name.outputs.current_branch }} --jobs 20 --recurse-submodules ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY} .
+    - name: Download ${{ github.ref_name }}.tar.gz artifact
+      uses: actions/download-artifact@v3
+      with:
+        name: ${{ github.ref_name }}.tar.gz
 
-      - name: Get Proton Versions
-        run: echo "RELEASE_VERSION=$(cat VERSION)" >> $GITHUB_ENV
-        
-      - name: Display version
-        run: echo ${{ env.RELEASE_VERSION }}
+    - name: Download ${{ github.ref_name }}.sha512sum artifact
+      uses: actions/download-artifact@v3
+      with:
+        name: ${{ github.ref_name }}.sha512sum
 
-      - name: Install dependencies apt
-        run: sudo apt update && sudo apt-get install -y ccache fontforge-nox
+    - name: Upload ${{ github.ref_name }}.tar.gz to release
+      uses: svenstaro/upload-release-action@2.5.0
+      with:
+        repo_token: ${{ secrets.GITHUB_TOKEN }}
+        tag: ${{ github.ref_name }}
+        file: ${{ github.ref_name }}.tar.gz
+        overwrite: false
 
-      - name: apply patches
-        run: ./patches/protonprep-valve-staging.sh  || true
-
-      - name: Create dir structure
-        run: mkdir build
-
-      - name: Create/Download ccache
-        uses: actions/cache@v2
-        with:
-          path: ~/.ccache
-          key: ccache-proton-${{ github.run_id }}
-          restore-keys: |
-            ccache-proton
-
-      - name: Configure build proton
-        working-directory: ./build/
-        run: ../configure.sh --build-name="${{ env.RELEASE_VERSION }}" --enable-ccache
-
-      # Build name following convention: Proton-<tag>
-      - name: Build proton
-        working-directory: ./build/
-        run: make dist
-
-      - name: Rename directory
-        working-directory: ./build/
-        run: mv dist ${{ env.RELEASE_VERSION }}
-
-      - name: Move files to their right folder
-        working-directory: ./build/${{ env.RELEASE_VERSION }}/protonfixes/
-        run: |
-          mv cabextract ../files/bin/ && \
-          mv libmspack.so.0 ../files/lib64/ && \
-          mv libmspack.so.0.1.0 ../files/lib64/ && \
-          rm cabextract_1.9-1.debian.tar.xz libmspack_0.10.1-1.debian.tar.xz
-
-      - name: Archive build
-        working-directory: ./build/
-        run: tar -czvf ${{ env.RELEASE_VERSION }}.tar.gz ${{ env.RELEASE_VERSION }}
-
-      - name: Upload binaries to release
-        uses: svenstaro/upload-release-action@v2
-        with:
-          repo_token: ${{ secrets.PROTON_GE_GITHUB_ACTIONS_BUILD }}
-          file: build/${{ env.RELEASE_VERSION }}.tar.gz
-          file_glob: true
-          tag: "${{ env.RELEASE_VERSION }}-build-${{ github.run_number }}"
-          overwrite: false
+    - name: Upload ${{ github.ref_name }}.sha512sum to release
+      uses: svenstaro/upload-release-action@2.5.0
+      with:
+        repo_token: ${{ secrets.GITHUB_TOKEN }}
+        tag: ${{ github.ref_name }}
+        file: ${{ github.ref_name }}.sha512sum
+        overwrite: false


### PR DESCRIPTION
* Add reusable Build workflow to build proton.
* Add Development workflow with manual dispatch only.
* Update Release workflow to build and release proton when a release is published.

Due to space constraints on Github Actions VM storage, the `CFLAGS` are patched through the workflow only (`Makefile.in` is untouched in repo) to omit debug symbols and strip binaries early, otherwise the workflow would fail.

The workflow uses `ccache` to speed up building and stores its cache for future usage. Without an existing cache the workflow's runtime is around 2 hours and 20 minutes, with an existing cache rebuilding the same sources it around 30 minutes. For an update it should be a bit less than an hour.