### PR TITLE
Include D8VK with proton-ge-custom

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -86,3 +86,6 @@
 [submodule "vosk-api"]
 	path = vosk-api
 	url = https://github.com/alphacep/vosk-api
+[submodule "d8vk"]
+	path = d8vk
+	url = https://github.com/AlpyneDreams/d8vk

--- a/Makefile
+++ b/Makefile
@@ -185,6 +185,12 @@ vkd3d-proton: any
 	cp -f $(BUILD_DIR)/dist/files/lib/wine/vkd3d-proton/*.dll $(BUILD_ROOT)/vkd3d-proton/lib/wine/vkd3d-proton/ && \
 	cp -f $(BUILD_DIR)/dist/files/lib64/wine/vkd3d-proton/*.dll $(BUILD_ROOT)/vkd3d-proton/lib64/wine/vkd3d-proton/
 
+d8vk: | $(BUILD_ROOT)/d8vk/lib/wine/d8vk
+d8vk: | $(BUILD_ROOT)/d8vk/lib64/wine/d8vk
+d8vk: any
+	cp -f $(BUILD_DIR)/dist/files/lib/wine/d8vk/*.dll $(BUILD_ROOT)/d8vk/lib/wine/d8vk/ && \
+	cp -f $(BUILD_DIR)/dist/files/lib64/wine/d8vk/*.dll $(BUILD_ROOT)/d8vk/lib64/wine/d8vk/
+
 lsteamclient: | $(BUILD_ROOT)/lsteamclient/lib/wine/i386-windows
 lsteamclient: | $(BUILD_ROOT)/lsteamclient/lib/wine/i386-unix
 lsteamclient: | $(BUILD_ROOT)/lsteamclient/lib64/wine/x86_64-windows

--- a/Makefile.in
+++ b/Makefile.in
@@ -754,6 +754,39 @@ $(OBJ)/.dxvk-nvapi-post-build32:
 
 
 ##
+## d8vk
+##
+
+D8VK_MESON_ARGS = \
+	-Denable_dxgi=false \
+	-Denable_d3d10=false \
+	-Denable_d3d11=false
+
+D8VK_MESON_ARGS32 = --bindir=$(D8VK_DST32)/lib/wine/d8vk
+D8VK_MESON_ARGS64 = --bindir=$(D8VK_DST64)/lib64/wine/d8vk
+D8VK_DEPENDS = glslang
+
+$(eval $(call rules-source,d8vk,$(SRCDIR)/d8vk))
+$(eval $(call rules-meson,d8vk,32,CROSS))
+$(eval $(call rules-meson,d8vk,64,CROSS))
+
+$(OBJ)/.d8vk-post-source:
+	sed -re 's#@VCS_TAG@#$(shell git -C $(SRCDIR)/d8vk describe --always --abbrev=15 --dirty=0)#' \
+	    $(SRCDIR)/d8vk/version.h.in > $(D8VK_SRC)/version.h.in
+	touch $@
+
+$(OBJ)/.d8vk-post-build64:
+	mkdir -p "$(DST_DIR)"/lib64/wine/d8vk
+	rm -f "$(DST_DIR)"/lib64/wine/d8vk/version && if test -e $(SRCDIR)/.git; then ( cd $(SRCDIR) && git submodule status -- d8vk ) > "$(DST_DIR)"/lib64/wine/d8vk/version; fi
+	touch $@
+
+$(OBJ)/.d8vk-post-build32:
+	mkdir -p "$(DST_DIR)"/lib/wine/d8vk
+	rm -f "$(DST_DIR)"/lib/wine/d8vk/version && if test -e $(SRCDIR)/.git; then ( cd $(SRCDIR) && git submodule status -- d8vk ) > "$(DST_DIR)"/lib/wine/d8vk/version; fi
+	touch $@
+
+
+##
 ## vkd3d
 ##
 
@@ -1255,7 +1288,7 @@ all-dist: $(DIST_OVR32) $(DIST_OVR64)
 ## default_pfx
 ##
 
-default_pfx: wine gst_good gst_libav gst_plugins_rs lsteamclient steamexe vrclient wineopenxr dxvk dxvk-nvapi vkd3d-proton
+default_pfx: wine gst_good gst_libav gst_plugins_rs lsteamclient steamexe vrclient wineopenxr dxvk dxvk-nvapi vkd3d-proton d8vk
 	find $(DST_LIBDIR32)/wine -type f -execdir chmod a-w '{}' '+'
 	find $(DST_LIBDIR64)/wine -type f -execdir chmod a-w '{}' '+'
 	rm -rf $(abspath $(DIST_PREFIX))

--- a/proton
+++ b/proton
@@ -1086,19 +1086,26 @@ class CompatData:
                 try_copy(g_proton.lib_dir + "vkd3d/libvkd3d-shader-1.dll", "drive_c/windows/syswow64",
                         prefix=self.prefix_dir, track_file=tracked_files, link_debug=True)
 
+                enable_d8vk = "enabled8vk" in g_session.compat_config
+
                 if use_wined3d:
                     dxvkfiles = []
+                    d8vkfiles = []
                     vkd3d_protonfiles = []
-                    wined3dfiles = ["d3d12", "d3d11", "d3d10", "d3d10core", "d3d10_1", "d3d9"]
+                    wined3dfiles = ["d3d12", "d3d11", "d3d10", "d3d10core", "d3d10_1", "d3d9", "d3d8"]
                 else:
                     dxvkfiles = ["d3d11", "d3d10core", "d3d9"]
+                    d8vkfiles = ["d3d8", "d3d9"] if enable_d8vk else []
                     vkd3d_protonfiles = ["d3d12", "d3d12core"]
-                    wined3dfiles = []
+                    wined3dfiles = [] if enable_d8vk else ["d3d8"]
 
                 if use_dxvk_dxgi:
                     dxvkfiles.append("dxgi")
                 else:
                     wined3dfiles.append("dxgi")
+
+                if dxvkfiles and enable_d8vk:
+                    dxvkfiles.remove("d3d9")
 
                 for f in wined3dfiles:
                     try_copy(g_proton.default_pfx_dir + "drive_c/windows/system32/" + f + ".dll", "drive_c/windows/system32",
@@ -1110,6 +1117,13 @@ class CompatData:
                     try_copy(g_proton.lib64_dir + "wine/dxvk/" + f + ".dll", "drive_c/windows/system32",
                             prefix=self.prefix_dir, track_file=tracked_files, link_debug=True)
                     try_copy(g_proton.lib_dir + "wine/dxvk/" + f + ".dll", "drive_c/windows/syswow64",
+                            prefix=self.prefix_dir, track_file=tracked_files, link_debug=True)
+                    g_session.dlloverrides[f] = "n"
+
+                for f in d8vkfiles:
+                    try_copy(g_proton.lib64_dir + "wine/d8vk/" + f + ".dll", "drive_c/windows/system32",
+                            prefix=self.prefix_dir, track_file=tracked_files, link_debug=True)
+                    try_copy(g_proton.lib_dir + "wine/d8vk/" + f + ".dll", "drive_c/windows/syswow64",
                             prefix=self.prefix_dir, track_file=tracked_files, link_debug=True)
                     g_session.dlloverrides[f] = "n"
 
@@ -1582,6 +1596,7 @@ class Session:
         self.check_environment("PROTON_HEAP_DELAY_FREE", "heapdelayfree")
         self.check_environment("PROTON_ENABLE_NVAPI", "enablenvapi")
         self.check_environment("PROTON_ENABLE_AMD_AGS", "enableamdags")
+        self.check_environment("PROTON_ENABLE_D8VK", "enabled8vk")
 
         if "noesync" in self.compat_config:
             self.env.pop("WINEESYNC", "")


### PR DESCRIPTION
Add and build D8VK as part of proton-ge-custom.

Use `PROTON_ENABLE_D8VK=1` to enable it. Because d8vk needs its own `d3d9.dll`, this will install `d3d8.dll` and `d3d9.dll` from d8vk instead of dxvk's `d3d9.dll`.
When the setting is not used or it is reverted, `d3d9.dll` from dxvk will be used instead and `d3d8.dll` will be reverted to wine's.

I included everything in a single commit so it can be easily reverted once D8VK is part of DXVK.

I tested with two games.
* Mafia: It runs as expected with D8VK
* Syberia II: Shows a black screen when D8VK is enabled, unsure if it is a build issue or a D8VK issue.

I have made a readily available binary here for anyone wanting to test before merging https://github.com/loathingKernel/Proton/releases/tag/untagged-71c70e7f688b288fbf07
(It was also a test of the workflow PR :smile:)