### PR TITLE
More codecs

### DIFF
--- a/CODECS.md
+++ b/CODECS.md
@@ -1,0 +1,23 @@
+
+#### Commands
+
+`ffprobe -v error -show_format -show_streams <file> | grep codec_name`
+
+`gst-discoverer-1.0 <file>`
+
+
+#### References
+
+* [FFMPEG codecs](https://ffmpeg.org/general.html)
+* [GStreamer plugins](https://gstreamer.freedesktop.org/documentation/plugins_doc.html)
+
+
+#### Game matrix
+| Game          | Video      | Audio    | Comments |
+|--|--|--|--|
+| Mafia         | indeo5     | adpcm_ms |  |
+| Crimson Skies | mpegvideo  | mp2      | Not available on Steam |
+|               | mpeg1video |          |  |
+| DOAXVV        | vc1        |          |  |
+|               | vc1image   |          | Untested |
+

--- a/Makefile.in
+++ b/Makefile.in
@@ -252,6 +252,7 @@ FFMPEG_CONFIGURE_ARGS := \
 	--disable-doc \
 	--enable-decoder=indeo5 \
 	--enable-decoder=adpcm_ms \
+	--enable-decoder=mpegvideo \
 	--enable-decoder=mpeg1video \
 	--enable-decoder=mp2 \
 	--enable-decoder=mpeg4 \


### PR DESCRIPTION
Add `mpegvideo` codec to ffmpeg, should complete Crimson Skies, Azumanga Fighter and possibly a lot of other early 2000s games.

Add a `CODECS.md` file to track video and audio codecs enabled, along with some useful command and links to be populated and documented over time.