### PR TITLE
Add asdf installation method

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,28 @@ PLEASE NOTE: There are prerequisites for using this version of proton:
 
 ### Manual
 
+#### Via [`asdf`, the version manager](https://asdf-vm.com/)
+
+There is an unofficial [plugin for installing and managing ProtonGE versions](https://github.com/augustobmoura/asdf-protonge)
+with [`asdf` (the universal version manager)](https://asdf-vm.com/), it follows
+the same process as the manual installation but makes it a lot easier. Managing
+versions by removing and updating to newer versions also becomes easier.
+
+To install by it first [install `asdf`](https://asdf-vm.com/guide/getting-started.html),
+and then proceed to add the ProtonGE plugin and install the version you want.
+``` bash
+asfd plugin add protonge
+
+# Or install a version from a tag (Eg.: GE-Proton8-25)
+asdf install protonge latest
+```
+
+It's also possible to use the asdf plugin in Flatpak installations, by
+customizing the target `compatibilitytools.d` path. For more settings check the
+[plugin's official documentation](https://github.com/augustobmoura/asdf-protonge)
+
+After every install you need to restart Steam, and [enable proton-ge-custom](#enabling).
+
 #### Native
 
 This section is for those that use the native version of Steam.


### PR DESCRIPTION
Hello! :wave: 

I wrote a plugin for installing and managing multiple versions of ProtonGE for [`asdf`, the version manager](https://github.com/augustobmoura/asdf-protonge). I've used it frequently for over a year, and it is pretty stable. It works the same way as the manual installation guide but does it by scripting. You can install multiple versions of Steam's directory and link them to asdf. So commands like this are possible:

```bash
asdf install protonge latest # Install latest version available to download
asdf install protonge latest:GE-Proton7 # Install latest version for Proton7

asdf uninstall protonge GE-Proton8-25 # Uninstall version Proton8-25
```

The commands are all automated, and we do checksum validation. It can also work with flatpak and other Steam installation methods by customizing the location of the `compatibilitytools.d`.

It would also be great to get some attention to it, as even though it is complete for release installs and uninstalls, there are a few features that would be nice to have with some contributions, like compiling from source for an arbitrary commit hash.

Link for the plugin https://github.com/augustobmoura/asdf-protonge