### PR TITLE
patches: Add fix for BeamNG.Drive VR (284160)

### DIFF
--- a/patches/game-patches/beamng-vr-fix.patch
+++ b/patches/game-patches/beamng-vr-fix.patch
@@ -1,0 +1,30 @@
+From 477fb8c55078dd48a88f881d92352b32e1567ff0 Mon Sep 17 00:00:00 2001
+From: gamingdoom <37276884+gamingdoom@users.noreply.github.com>
+Date: Sat, 30 Dec 2023 14:06:37 -0800
+Subject: [PATCH] Fix BeamNG.Drive VR
+
+---
+ openxr.c | 7 +++++++
+ 1 file changed, 7 insertions(+)
+
+diff --git a/openxr.c b/openxr.c
+index 0a4b9c18..0264a7eb 100644
+--- a/openxr.c
++++ b/openxr.c
+@@ -1599,6 +1599,13 @@ XrResult WINAPI wine_xrGetVulkanDeviceExtensionsKHR(XrInstance instance, XrSyste
+     char *buf;
+ 
+     WINE_TRACE("%p, 0x%s, %u, %p, %p\n", instance, wine_dbgstr_longlong(systemId), bufferCapacityInput, bufferCountOutput, buffer);
++    
++    const char *sgi = getenv("SteamGameId");
++
++    if (sgi && strcmp(sgi, "284160") == 0) {
++        *bufferCountOutput = 0;
++        return XR_SUCCESS;
++    }
+ 
+     if(bufferCapacityInput == 0){
+         *bufferCountOutput = sizeof(WINE_VULKAN_DEVICE_EXTENSION_NAME);
+-- 
+2.43.0
+

--- a/patches/game-patches/beamng-vr-fix.patch
+++ b/patches/game-patches/beamng-vr-fix.patch
@@ -1,30 +1,54 @@
-From 477fb8c55078dd48a88f881d92352b32e1567ff0 Mon Sep 17 00:00:00 2001
+From 4511edb4a14f39fbcb5bc0d178f4c91b2e88a04c Mon Sep 17 00:00:00 2001
 From: gamingdoom <37276884+gamingdoom@users.noreply.github.com>
-Date: Sat, 30 Dec 2023 14:06:37 -0800
-Subject: [PATCH] Fix BeamNG.Drive VR
+Date: Sat, 30 Dec 2023 16:10:12 -0800
+Subject: [PATCH] More robust BeamNG.Drive VR Patch
 
 ---
- openxr.c | 7 +++++++
- 1 file changed, 7 insertions(+)
+ openxr.c | 18 ++++++++++++++----
+ 1 file changed, 14 insertions(+), 4 deletions(-)
 
 diff --git a/openxr.c b/openxr.c
-index 0a4b9c18..0264a7eb 100644
+index 0a4b9c18..2f6af119 100644
 --- a/openxr.c
 +++ b/openxr.c
-@@ -1599,6 +1599,13 @@ XrResult WINAPI wine_xrGetVulkanDeviceExtensionsKHR(XrInstance instance, XrSyste
-     char *buf;
+@@ -1600,14 +1600,22 @@ XrResult WINAPI wine_xrGetVulkanDeviceExtensionsKHR(XrInstance instance, XrSyste
  
      WINE_TRACE("%p, 0x%s, %u, %p, %p\n", instance, wine_dbgstr_longlong(systemId), bufferCapacityInput, bufferCountOutput, buffer);
-+    
+ 
+-    if(bufferCapacityInput == 0){
 +    const char *sgi = getenv("SteamGameId");
 +
-+    if (sgi && strcmp(sgi, "284160") == 0) {
++    if(bufferCapacityInput == 0 && ((!sgi) | (sgi && strcmp(sgi, "284160") != 0))){
+         *bufferCountOutput = sizeof(WINE_VULKAN_DEVICE_EXTENSION_NAME);
+         return XR_SUCCESS;
++    } else if (bufferCapacityInput == 0 && (sgi && strcmp(sgi, "284160") == 0)){
 +        *bufferCountOutput = 0;
 +        return XR_SUCCESS;
+     }
+ 
+-    if(bufferCapacityInput < sizeof(WINE_VULKAN_DEVICE_EXTENSION_NAME)){
++    if((bufferCapacityInput < sizeof(WINE_VULKAN_DEVICE_EXTENSION_NAME) && ((!sgi) | (sgi && strcmp(sgi, "284160") != 0)))){
+         *bufferCountOutput = sizeof(WINE_VULKAN_DEVICE_EXTENSION_NAME);
+         return XR_ERROR_SIZE_INSUFFICIENT;
++    } else if (bufferCapacityInput < sizeof(WINE_VULKAN_DEVICE_EXTENSION_NAME) && (sgi && strcmp(sgi, "284160") == 0)){
++        *bufferCountOutput = 0;
++        return XR_SUCCESS;
+     }
+ 
+     res = ((wine_XrInstance *)instance)->funcs.p_xrGetVulkanDeviceExtensionsKHR(
+@@ -1634,8 +1642,10 @@ XrResult WINAPI wine_xrGetVulkanDeviceExtensionsKHR(XrInstance instance, XrSyste
+ 
+     heap_free(buf);
+ 
+-    memcpy(buffer, WINE_VULKAN_DEVICE_EXTENSION_NAME, sizeof(WINE_VULKAN_DEVICE_EXTENSION_NAME));
+-    *bufferCountOutput = sizeof(WINE_VULKAN_DEVICE_EXTENSION_NAME);
++    if ((!sgi) | (sgi && strcmp(sgi, "284160") != 0)) {
++        memcpy(buffer, WINE_VULKAN_DEVICE_EXTENSION_NAME, sizeof(WINE_VULKAN_DEVICE_EXTENSION_NAME));
++        *bufferCountOutput = sizeof(WINE_VULKAN_DEVICE_EXTENSION_NAME);
 +    }
  
-     if(bufferCapacityInput == 0){
-         *bufferCountOutput = sizeof(WINE_VULKAN_DEVICE_EXTENSION_NAME);
+     return XR_SUCCESS;
+ }
 -- 
 2.43.0
 

--- a/patches/protonprep-valve-staging.sh
+++ b/patches/protonprep-valve-staging.sh
@@ -376,4 +376,22 @@
     #patch -Np1 < ../patches/proton/71-invert-fsr-logic.patch
 
 ### END PROTON-GE ADDITIONAL CUSTOM PATCHES ###
+
+    cd ..
+
 ### END WINE PATCHING ###
+
+### (3) WINEOPENXR PATCHING ###
+
+     cd wineopenxr
+
+### (3-1) GAME PATCH SECTION ###
+
+     echo "WINEOPENXR: -GAME FIXES- BeamNG.Drive VR Fix"
+     patch -Np1 < ../patches/game-patches/beamng-vr-fix.patch
+
+### END GAME PATCH SECTION ###
+
+     cd ..
+
+### END WINEOPENXR PATCHING ###


### PR DESCRIPTION
Removing the VK_WINE_openxr_device_extensions openxr extension from the device extensions fixes BeamNG.Drive's VR mode, which doesn't work at all without this patch.