### PR TITLE
proton: Fix typo for protontricks call

### DIFF
--- a/proton
+++ b/proton
@@ -1685,7 +1685,7 @@ class Session:
             after_winetricks = self.cmdlineappend.split('winetricks', 1)[1]
             arguments = after_winetricks.split()
             if len(arguments) == 0:
-                protonfixes.util.protontricks(gui)
+                protonfixes.util.protontricks('gui')
             else:
                 protonfixes.util.protontricks(arguments)
             sys.exit(0)


### PR DESCRIPTION
`gui` is a unique verb in protontricks and it isn't a variable that exists in any scope within the file, so this function call should fail.