### PR TITLE
Remove output redirection from example install script

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,14 +128,14 @@ echo "Fetching tarball URL..."
 tarball_url=$(curl -s https://api.github.com/repos/GloriousEggroll/proton-ge-custom/releases/latest | grep browser_download_url | cut -d\" -f4 | grep .tar.gz)
 tarball_name=$(basename $tarball_url)
 echo "Downloading tarball: $tarball_name..."
-curl -# -L $tarball_url -o $tarball_name 2>&1
+curl -# -L $tarball_url -o $tarball_name
 
 # download checksum
 echo "Fetching checksum URL..."
 checksum_url=$(curl -s https://api.github.com/repos/GloriousEggroll/proton-ge-custom/releases/latest | grep browser_download_url | cut -d\" -f4 | grep .sha512sum)
 checksum_name=$(basename $checksum_url)
 echo "Downloading checksum: $checksum_name..."
-curl -# -L $checksum_url -o $checksum_name 2>&1
+curl -# -L $checksum_url -o $checksum_name
 
 # check tarball with checksum
 echo "Verifying tarball $tarball_name with checksum $checksum_name..."

--- a/README.md
+++ b/README.md
@@ -128,14 +128,14 @@ echo "Fetching tarball URL..."
 tarball_url=$(curl -s https://api.github.com/repos/GloriousEggroll/proton-ge-custom/releases/latest | grep browser_download_url | cut -d\" -f4 | grep .tar.gz)
 tarball_name=$(basename $tarball_url)
 echo "Downloading tarball: $tarball_name..."
-curl -# -L $tarball_url -o $tarball_name
+curl -# -L $tarball_url -o $tarball_name --no-progress-meter
 
 # download checksum
 echo "Fetching checksum URL..."
 checksum_url=$(curl -s https://api.github.com/repos/GloriousEggroll/proton-ge-custom/releases/latest | grep browser_download_url | cut -d\" -f4 | grep .sha512sum)
 checksum_name=$(basename $checksum_url)
 echo "Downloading checksum: $checksum_name..."
-curl -# -L $checksum_url -o $checksum_name
+curl -# -L $checksum_url -o $checksum_name --no-progress-meter
 
 # check tarball with checksum
 echo "Verifying tarball $tarball_name with checksum $checksum_name..."


### PR DESCRIPTION
removing the "2>&1" output redirection, as it causes /var/log/messages to fill up with download progressbar spam.