### PR TITLE
Revert "Include d8vk"

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -86,6 +86,3 @@
 [submodule "vosk-api"]
 	path = vosk-api
 	url = https://github.com/alphacep/vosk-api
-[submodule "d8vk"]
-	path = d8vk
-	url = https://github.com/AlpyneDreams/d8vk

--- a/Makefile
+++ b/Makefile
@@ -185,12 +185,6 @@ vkd3d-proton: any
 	cp -f $(BUILD_DIR)/dist/files/lib/wine/vkd3d-proton/*.dll $(BUILD_ROOT)/vkd3d-proton/lib/wine/vkd3d-proton/ && \
 	cp -f $(BUILD_DIR)/dist/files/lib64/wine/vkd3d-proton/*.dll $(BUILD_ROOT)/vkd3d-proton/lib64/wine/vkd3d-proton/
 
-d8vk: | $(BUILD_ROOT)/d8vk/lib/wine/d8vk
-d8vk: | $(BUILD_ROOT)/d8vk/lib64/wine/d8vk
-d8vk: any
-	cp -f $(BUILD_DIR)/dist/files/lib/wine/d8vk/*.dll $(BUILD_ROOT)/d8vk/lib/wine/d8vk/ && \
-	cp -f $(BUILD_DIR)/dist/files/lib64/wine/d8vk/*.dll $(BUILD_ROOT)/d8vk/lib64/wine/d8vk/
-
 lsteamclient: | $(BUILD_ROOT)/lsteamclient/lib/wine/i386-windows
 lsteamclient: | $(BUILD_ROOT)/lsteamclient/lib/wine/i386-unix
 lsteamclient: | $(BUILD_ROOT)/lsteamclient/lib64/wine/x86_64-windows

--- a/Makefile.in
+++ b/Makefile.in
@@ -786,42 +786,6 @@ $(OBJ)/.dxvk-nvapi-post-build32:
 
 
 ##
-## d8vk
-##
-
-D8VK_MESON_ARGS = \
-	-Denable_dxgi=false \
-	-Denable_d3d10=false \
-	-Denable_d3d11=false
-
-D8VK_MESON_ARGS32 = --bindir=$(D8VK_DST32)/lib/wine/d8vk
-D8VK_MESON_ARGS64 = --bindir=$(D8VK_DST64)/lib64/wine/d8vk
-D8VK_DEPENDS = glslang
-
-$(eval $(call rules-source,d8vk,$(SRCDIR)/d8vk))
-$(eval $(call rules-meson,d8vk,32,CROSS))
-$(eval $(call rules-meson,d8vk,64,CROSS))
-
-$(OBJ)/.d8vk-post-source:
-	sed -re 's#@VCS_TAG@#$(shell git -C $(SRCDIR)/d8vk describe --always --abbrev=15 --dirty=0)#' \
-	    $(SRCDIR)/d8vk/version.h.in > $(D8VK_SRC)/version.h.in
-	touch $@
-
-$(OBJ)/.d8vk-post-build64:
-	mkdir -p "$(DST_DIR)"/lib64/wine/d8vk
-	rm -f "$(DST_DIR)"/lib64/wine/d8vk/version && if test -e $(SRCDIR)/.git; then ( cd $(SRCDIR) && git submodule status -- d8vk ) > "$(DST_DIR)"/lib64/wine/d8vk/version; fi
-	touch $@
-
-$(OBJ)/.d8vk-post-build32:
-	mkdir -p "$(DST_DIR)"/lib/wine/d8vk
-	rm -f "$(DST_DIR)"/lib/wine/d8vk/version && if test -e $(SRCDIR)/.git; then ( cd $(SRCDIR) && git submodule status -- d8vk ) > "$(DST_DIR)"/lib/wine/d8vk/version; fi
-	touch $@
-
-# wine builds DLLs with the same names, we need to differentiate the timestamps
-D8VK_SOURCE_DATE_EPOCH32 := $(shell expr $(BASE_SOURCE_DATE_EPOCH32) - 1)
-D8VK_SOURCE_DATE_EPOCH64 := $(shell expr $(BASE_SOURCE_DATE_EPOCH64) - 1)
-
-##
 ## vkd3d
 ##
 
@@ -1325,7 +1289,7 @@ all-dist: $(DIST_OVR32) $(DIST_OVR64)
 ## default_pfx
 ##
 
-default_pfx: wine gst_good gst_libav gst_plugins_rs lsteamclient steamexe vrclient wineopenxr dxvk dxvk-nvapi vkd3d-proton d8vk
+default_pfx: wine gst_good gst_libav gst_plugins_rs lsteamclient steamexe vrclient wineopenxr dxvk dxvk-nvapi vkd3d-proton
 	find $(DST_LIBDIR32)/wine -type f -execdir chmod a-w '{}' '+'
 	find $(DST_LIBDIR64)/wine -type f -execdir chmod a-w '{}' '+'
 	rm -rf $(abspath $(DIST_PREFIX))

--- a/proton
+++ b/proton
@@ -1024,26 +1024,19 @@ class CompatData:
                 try_copy(g_proton.lib_dir + "vkd3d/libvkd3d-shader-1.dll", "drive_c/windows/syswow64",
                         prefix=self.prefix_dir, track_file=tracked_files, link_debug=True)
 
-                enable_d8vk = "enabled8vk" in g_session.compat_config
-
                 if use_wined3d:
                     dxvkfiles = []
-                    d8vkfiles = []
                     vkd3d_protonfiles = []
-                    wined3dfiles = ["d3d12", "d3d11", "d3d10", "d3d10core", "d3d10_1", "d3d9", "d3d8"]
+                    wined3dfiles = ["d3d12", "d3d11", "d3d10", "d3d10core", "d3d10_1", "d3d9"]
                 else:
                     dxvkfiles = ["d3d11", "d3d10core", "d3d9"]
-                    d8vkfiles = ["d3d8", "d3d9"] if enable_d8vk else []
                     vkd3d_protonfiles = ["d3d12", "d3d12core"]
-                    wined3dfiles = [] if enable_d8vk else ["d3d8"]
+                    wined3dfiles = []
 
                 if use_dxvk_dxgi:
                     dxvkfiles.append("dxgi")
                 else:
                     wined3dfiles.append("dxgi")
-
-                if dxvkfiles and enable_d8vk:
-                    dxvkfiles.remove("d3d9")
 
                 for f in wined3dfiles:
                     try_copy(g_proton.default_pfx_dir + "drive_c/windows/system32/" + f + ".dll", "drive_c/windows/system32",
@@ -1055,13 +1048,6 @@ class CompatData:
                     try_copy(g_proton.lib64_dir + "wine/dxvk/" + f + ".dll", "drive_c/windows/system32",
                             prefix=self.prefix_dir, track_file=tracked_files, link_debug=True)
                     try_copy(g_proton.lib_dir + "wine/dxvk/" + f + ".dll", "drive_c/windows/syswow64",
-                            prefix=self.prefix_dir, track_file=tracked_files, link_debug=True)
-                    g_session.dlloverrides[f] = "n"
-
-                for f in d8vkfiles:
-                    try_copy(g_proton.lib64_dir + "wine/d8vk/" + f + ".dll", "drive_c/windows/system32",
-                            prefix=self.prefix_dir, track_file=tracked_files, link_debug=True)
-                    try_copy(g_proton.lib_dir + "wine/d8vk/" + f + ".dll", "drive_c/windows/syswow64",
                             prefix=self.prefix_dir, track_file=tracked_files, link_debug=True)
                     g_session.dlloverrides[f] = "n"
 
@@ -1492,7 +1478,6 @@ class Session:
         self.check_environment("PROTON_DISABLE_NVAPI", "disablenvapi")
         self.check_environment("PROTON_FORCE_NVAPI", "forcenvapi")
         self.check_environment("PROTON_HIDE_APU", "hideapu")
-        self.check_environment("PROTON_ENABLE_D8VK", "enabled8vk")
 
         if "noesync" in self.compat_config:
             self.env.pop("WINEESYNC", "")


### PR DESCRIPTION
The [D8VK pull request](https://github.com/doitsujin/dxvk/pull/3411) has been merged into DXVK, so revert everything related to it before syncing with an upstream version that includes it.

This reverts commit ba67550b3555017efa71d4bd7e9d1dc6e750f059.