### PR TITLE
build: add build target for protonfixes

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -1338,6 +1338,7 @@ $(PROTONFIXES_TARGET): $(addprefix $(SRCDIR)/,protonfixes)
 
 $(OBJ)/.build-protonfixes:
 	cd $(SRCDIR)/protonfixes && make
+	touch $(@)
 
 $(PROTONFIXES_TARGET): $(OBJ)/.build-protonfixes
 	cd $(SRCDIR)/protonfixes && make install

--- a/Makefile.in
+++ b/Makefile.in
@@ -1336,19 +1336,15 @@ all-dist: $(DIST_LICENSE) $(DIST_OFL_LICENSE) $(DIST_AV1_PATENTS)
 PROTONFIXES_TARGET := $(addprefix $(DST_BASE)/,protonfixes)
 $(PROTONFIXES_TARGET): $(addprefix $(SRCDIR)/,protonfixes)
 
-$(OBJ)/.build-protonfixes-dist:
-	cd protonfixes && make
+$(OBJ)/.build-protonfixes:
+	cd $(SRCDIR)/protonfixes && make
 
-.PHONY: protonfixes-dist
-
-protonfixes-dist: $(OBJDIR)/.build-protonfixes-dist
-
-protonfixes-install: protonfixes-dist
-	cd protonfixes && make install
+$(PROTONFIXES_TARGET): $(OBJ)/.build-protonfixes
+	cd $(SRCDIR)/protonfixes && make install
 	cp -a $(SRCDIR)/protonfixes/dist/protonfixes $(PROTONFIXES_TARGET)
 	rm -r $(SRCDIR)/protonfixes/dist
 
-all-dist: protonfixes-install
+all-dist: $(PROTONFIXES_TARGET)
 
 ##
 ## proton(.py), filelock.py, etc.

--- a/Makefile.in
+++ b/Makefile.in
@@ -1329,6 +1329,30 @@ $(DIST_AV1_PATENTS): $(AV1_PATENTS)
 
 all-dist: $(DIST_LICENSE) $(DIST_OFL_LICENSE) $(DIST_AV1_PATENTS)
 
+##
+## protonfixes
+##
+
+PROTONFIXES_TARGET := $(addprefix $(DST_BASE)/,protonfixes)
+$(PROTONFIXES_TARGET): $(addprefix $(SRCDIR)/,protonfixes)
+
+$(OBJ)/.build-protonfixes-dist:
+    cd protonfixes && \
+    make
+    touch $(@)
+
+.PHONY: protonfixes-dist
+
+protonfixes-dist: $(OBJDIR)/.build-protonfixes-dist
+
+protonfixes-install: protonfixes-dist
+    cd protonfixes && \
+    make install
+    # Post install
+    cp -a $(SRCDIR)/protonfixes/dist/protonfixes $(PROTONFIXES_TARGET)
+    rm -r $(SRCDIR)/protonfixes/dist
+
+all-dist: protonfixes-install
 
 ##
 ## proton(.py), filelock.py, etc.
@@ -1346,12 +1370,8 @@ $(PROTON37_TRACKED_FILES_TARGET): $(addprefix $(SRCDIR)/,proton_3.7_tracked_file
 USER_SETTINGS_PY_TARGET := $(addprefix $(DST_BASE)/,user_settings.sample.py)
 $(USER_SETTINGS_PY_TARGET): $(addprefix $(SRCDIR)/,user_settings.sample.py)
 
-PROTONFIXES_TARGET := $(addprefix $(DST_BASE)/,protonfixes)
-$(PROTONFIXES_TARGET): $(addprefix $(SRCDIR)/,protonfixes)
-
 DIST_COPY_TARGETS := $(FILELOCK_TARGET) $(PROTON_PY_TARGET) \
-                     $(PROTON37_TRACKED_FILES_TARGET) $(USER_SETTINGS_PY_TARGET) \
-                     $(PROTONFIXES_TARGET)
+                     $(PROTON37_TRACKED_FILES_TARGET) $(USER_SETTINGS_PY_TARGET)
 
 $(DIST_COPY_TARGETS): | $(DST_DIR)
 	cp -a $(SRCDIR)/$(notdir $@) $@

--- a/Makefile.in
+++ b/Makefile.in
@@ -1337,20 +1337,16 @@ PROTONFIXES_TARGET := $(addprefix $(DST_BASE)/,protonfixes)
 $(PROTONFIXES_TARGET): $(addprefix $(SRCDIR)/,protonfixes)
 
 $(OBJ)/.build-protonfixes-dist:
-    cd protonfixes && \
-    make
-    touch $(@)
+	cd protonfixes && make
 
 .PHONY: protonfixes-dist
 
 protonfixes-dist: $(OBJDIR)/.build-protonfixes-dist
 
 protonfixes-install: protonfixes-dist
-    cd protonfixes && \
-    make install
-    # Post install
-    cp -a $(SRCDIR)/protonfixes/dist/protonfixes $(PROTONFIXES_TARGET)
-    rm -r $(SRCDIR)/protonfixes/dist
+	cd protonfixes && make install
+	cp -a $(SRCDIR)/protonfixes/dist/protonfixes $(PROTONFIXES_TARGET)
+	rm -r $(SRCDIR)/protonfixes/dist
 
 all-dist: protonfixes-install
 


### PR DESCRIPTION
Depends on https://github.com/Open-Wine-Components/umu-protonfixes/pull/100 being merged, which adds an initial build system for protonfixes to build current and future packages from source.

protonfixes currently commits the binaries for `cabextract`, `libmspack.so`, and `xrandr` to the repository which are needed for winetricks and some protonfixes functionality to work. While this works, it isn't guaranteed to be reliable nor sustainable if we decide to commit more binaries to that repo for fixes. Instead of committing those files to the repo, we should prefer to build them from source within the Steam Runtime container to guarantee the reliability of those files between major SLRs versions, and to provide users some transparency by specifying those files' source repository.

TODO:

- [ ] Test build
