### PR TITLE
configure.sh: Add option to disable SELinux labeling for container volumes.

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -1423,6 +1423,10 @@ else
 	override DOCKER_OPTS := $(CCACHE_ENV) -e CCACHE_DISABLE=1 $(DOCKER_OPTS)
 endif
 
+ifeq ($(DISABLE_LABELING),1)
+	override DOCKER_OPTS := --security-opt label=disable $(DOCKER_OPTS)
+endif
+
 export CARGO_HOME := $(if $(CARGO_HOME),$(CARGO_HOME),$(HOME)/.cargo)
 override DOCKER_OPTS := -v $(CARGO_HOME):$(CARGO_HOME)$(CONTAINER_MOUNT_OPTS) -e CARGO_HOME=$(CARGO_HOME) $(DOCKER_OPTS)
 

--- a/configure.sh
+++ b/configure.sh
@@ -55,14 +55,19 @@ check_container_engine() {
         return 1
     fi
 
+    label_opt=""
+    if [[ -n $arg_disable_labeling ]]; then
+      label_opt="--security-opt label=disable"
+    fi
     touch permission_check
     local inner_uid="$($1 run -v "$(pwd):/test$CONTAINER_MOUNT_OPTS" \
+                                            $label_opt \
                                             --rm $2 \
                                             stat --format "%u" /test/permission_check 2>&1)"
     rm permission_check
 
     if [[ $inner_uid == *"Permission denied"* ]]; then
-        err "The container cannot access files. Are you using SELinux?"
+        err "The container cannot access files. If you're using SELinux, try passing --disable-labeling or --relabel-volumes."
         die "Please read README.md and check your $1 setup works."
     elif [ "$inner_uid" -eq 0 ]; then
         # namespace maps the user as root or the build is performed as host's root
@@ -164,6 +169,9 @@ function configure() {
     if [[ -n "$arg_docker_opts" ]]; then
       echo "DOCKER_OPTS := $arg_docker_opts"
     fi
+    if [[ -n "$arg_disable_labeling" ]]; then
+      echo "DISABLE_LABELING := 1"
+    fi
     if [[ -n "$CONTAINER_MOUNT_OPTS" ]]; then
       echo "CONTAINER_MOUNT_OPTS := $CONTAINER_MOUNT_OPTS"
     fi
@@ -192,6 +200,7 @@ arg_build_name=""
 arg_container_engine=""
 arg_docker_opts=""
 arg_relabel_volumes=""
+arg_disable_labeling=""
 arg_enable_ccache=""
 arg_enable_bear=""
 arg_help=""
@@ -238,6 +247,8 @@ function parse_args() {
       val_used=1
     elif [[ $arg = --relabel-volumes ]]; then
       arg_relabel_volumes="1"
+    elif [[ $arg = --disable-labeling ]]; then
+      arg_disable_labeling="1"
     elif [[ $arg = --enable-ccache ]]; then
       arg_enable_ccache="1"
     elif [[ $arg = --enable-bear ]]; then


### PR DESCRIPTION
Adds `--disable-labeling` to configure.sh. Passing this option passes `--security-opt label=disable` to the container arguments, which disables SELinux labeling. This is something of a nuclear option compared to :z or :Z for volume binds, but far simpler and basically guaranteed to work, and for a build container the security implications hardly matter.

The existing `--relabel-volumes` option which passes `:Z` (capital) is a little bit not-nice because it relabels the files on the host (`:z`, lowercase, only relabels them in the container).