### PR TITLE
Apply patch to fix wine bug 56653

### DIFF
--- a/patches/protonprep-valve-staging.sh
+++ b/patches/protonprep-valve-staging.sh
@@ -339,6 +339,9 @@
     echo "WINE: -CUSTOM- Downgrade MESSAGE to TRACE to remove write_watches spam"
     patch -Np1 < ../patches/proton/0001-ntdll-Downgrade-using-kernel-write-watches-from-MESS.patch
 
+    echo "WINE: -CUSTOM- Fix wine bug #56653 - GetLogicalProcessorInformation can be missing Cache information"
+    patch -Np1 < ../patches/wine-bug-56653.patch
+
     popd
 
 ### END PROTON-GE ADDITIONAL CUSTOM PATCHES ###

--- a/patches/wine-bug-56653.patch
+++ b/patches/wine-bug-56653.patch
@@ -1,0 +1,47 @@
+diff --git a/dlls/ntdll/unix/system.c b/dlls/ntdll/unix/system.c
+index 461922db7b0..1df4e2f3356 100644
+--- a/dlls/ntdll/unix/system.c
++++ b/dlls/ntdll/unix/system.c
+@@ -35,6 +35,7 @@
+ #include <errno.h>
+ #include <assert.h>
+ #include <sys/time.h>
++#include <sys/stat.h>
+ #include <time.h>
+ #include <dirent.h>
+ #ifdef HAVE_SYS_PARAM_H
+@@ -1148,6 +1149,7 @@ static NTSTATUS create_logical_proc_info(void)
+ {
+     static const char core_info[] = "/sys/devices/system/cpu/cpu%u/topology/%s";
+     static const char cache_info[] = "/sys/devices/system/cpu/cpu%u/cache/index%u/%s";
++    static const char cache_info_dir[] = "/sys/devices/system/cpu/cpu%u/cache";
+     static const char numa_info[] = "/sys/devices/system/node/node%u/cpumap";
+     const char *env_fake_logical_cores = getenv("WINE_LOGICAL_CPUS_AS_CORES");
+     BOOL fake_logical_cpus_as_cores = env_fake_logical_cores && atoi(env_fake_logical_cores);
+@@ -1156,6 +1158,7 @@ static NTSTATUS create_logical_proc_info(void)
+     char op, name[MAX_PATH];
+     ULONG_PTR all_cpus_mask = 0;
+     unsigned int cpu_id;
++    struct stat cache_dir_stat;
+ 
+     /* On systems with a large number of CPU cores (32 or 64 depending on 32-bit or 64-bit),
+      * we have issues parsing processor information:
+@@ -1262,6 +1265,18 @@ static NTSTATUS create_logical_proc_info(void)
+             }
+ 
+             cpu_id = cpu_override.mapping.cpu_count ? cpu_override.mapping.host_cpu_id[i] : i;
++            
++            snprintf(name, sizeof(name), cache_info_dir, cpu_id);
++            if(stat(name, &cache_dir_stat) != 0){
++                // Adding cache will fail in the next block so we add a fake one
++                CACHE_DESCRIPTOR fake_cache = { .Associativity = 8, .LineSize = 64, .Type = CacheUnified, .Size = 64 * 1024, .Level = 1 };
++                if (!logical_proc_info_add_cache( all_cpus_mask, &fake_cache ))
++                {
++                    fclose(fcpu_list);
++                    return STATUS_NO_MEMORY;
++                }
++            }
++
+ 
+             for(j = 0; j < 4; j++)
+             {


### PR DESCRIPTION
BG3 wasn't working on my new laptop using any version of proton 8.0, proton 9.0, proton experimental, or proton GE. I did a bit of digging and came across a thread on the arch linux forums [^1] which seemed to be a similar issue and included a fix. The thread references a bug in wine [^2] which is fixed in wine 9.9 [^3]. No version of proton includes wine 9.9. I added the patch from the thread, compiled a new version, and everything worked flawlessly.

The issue suggested in the linked bug reports is that wine doesn't understand something about my CPU, and fails to report some critical information when the BG3 engine queries for it. This leads to the game stalling at 95% on the initial loading screen. A segfault is reported in the BG3 logs.

Applying this fix also made Divinity 2 Original Sin run on this machine, which makes sense as they are the same game engine.

The bug is fixed in Wine 9.9 [^3], but the code has been refactored considerably so cherry picking that bug fix is difficult. This patch is written by admiral0 on the arch linux forums [^4] specifically to target wine 9.0 in Proton-GE. I don't understand the different categories of wine patches in proton-ge so I just placed it in the patch root directory. I'm happy to move the patch to the correct place myself or for you to move it where you think it belongs. I also reported this issue to Valve [^5].

[^1]: Arch Linux forum thread with a similar problem and a fix: https://bbs.archlinux.org/viewtopic.php?id=298140
[^2]: Wine bug report: https://bugs.winehq.org/show_bug.cgi?id=56653
[^3]: Wine 9.9 fix: https://gitlab.winehq.org/wine/wine/-/commit/e4db1b39ea28d0cc1b20ef4eacbb237c2f6cb68b
[^4]: Custom patch by admiral0: https://bbs.archlinux.org/viewtopic.php?pid=2199850#p2199850
[^5]: My bug report on the BG3 Proton issue tracker: https://github.com/ValveSoftware/Proton/issues/4243#issuecomment-2520039153
