### PR TITLE
proton: preserve drive letter for different mount points

### DIFF
--- a/proton
+++ b/proton
@@ -408,19 +408,16 @@ def is_directory_empty(dir_path):
 
 def setup_game_dir_drive():
         if os.environ.get('UMU_ID', ''):
-            directories_to_check = [
-                '/media',
-                '/run/media',
-                '/mnt',
-                os.path.expanduser("~")  # Current user's home directory
-            ]
+            drive_map = {
+                "/media": "u:",
+                "/run/media": "v:",
+                "/mnt": "w:",
+                os.path.expanduser("~"): "x:"  # Current user's home directory
+            }
 
-            drive_letter = ord('u')  # Start from 'u'
-
-            for directory in directories_to_check:
+            for directory in drive_map.keys():
                 if os.path.exists(directory) and not is_directory_empty(directory):
-                    setup_dir_drive("gamedrive", f"{chr(drive_letter)}:", directory)
-                    drive_letter += 1  # Increment to the next drive letter
+                    setup_dir_drive("gamedrive", drive_map[directory], directory)
         else:
             setup_dir_drive("gamedrive", "s:", try_get_game_library_dir())
 


### PR DESCRIPTION
https://discord.com/channels/110175050006577152/522638111042437132/1324478921688875089

> regarding this feature (since 9-16): "games run with UMU will now have /mnt,/run/media,/media/, and the user's home folder added as drives u:,v:,w:,x: respectively inside the prefix if they are not empty", are the drive mappings supposed to change on the fly depending on whether /mnt, /run/media and/or /media are mounted? In my case, on a system with none of the three currently mounted, the prefix is created with U: pointing to $HOME; but if I mount something on e.g. /mnt, then U: now points to /mnt and V: is created to point to $HOME, thereby breaking all kinds of stuff until I manually fix their configured paths. Shouldn't these 4 paths be hardcoded to the 4 letters, i.e. $HOME should always be reachable via X: regardless of whatever else is mounted currently or in the future?
