### PR TITLE
build: Don't list removed --enable-cache as configure option.

### DIFF
--- a/configure.sh
+++ b/configure.sh
@@ -309,8 +309,6 @@ usage() {
   "$1" ""
   "$1" "    --relabel-volumes Bind-mounted volumes will be relabeled. Use with caution."
   "$1" ""
-  "$1" "    --enable-ccache Mount \$CCACHE_DIR or \$HOME/.ccache inside of the container and use ccache for the build."
-  "$1" ""
   "$1" "    --enable-bear Invokes make via bear creating compile_commands.json."
   "$1" ""
   "$1" "  Steam Runtime"


### PR DESCRIPTION
> ccache enabled by default in configure script, --enable-ccache option no longer needs specifying during building

Even though the `--enable-ccache` option was removed from the configure script, it is still shown in the option list. I simple removed its mention from the configure script.