### PR TITLE
proton: use fully qualified path for start.exe

### DIFF
--- a/proton
+++ b/proton
@@ -1866,7 +1866,7 @@ class Session:
             log(sys.argv[2])
             if len(sys.argv) >=  3 and sys.argv[2].startswith('/'):
                 log("Executable a unix path, launching with /unix option.")
-                argv = [g_proton.wine64_bin, "start", "/wait", "/unix"]
+                argv = [g_proton.wine64_bin, "c:\\windows\\system32\\start.exe", "/wait", "/unix"]
             else:
                 log("Executable is inside wine prefix, launching normally.")
                 argv = [g_proton.wine64_bin]

--- a/proton
+++ b/proton
@@ -1866,7 +1866,7 @@ class Session:
             log(sys.argv[2])
             if len(sys.argv) >=  3 and sys.argv[2].startswith('/'):
                 log("Executable a unix path, launching with /unix option.")
-                argv = [g_proton.wine64_bin, "start", "/unix"]
+                argv = [g_proton.wine64_bin, "start", "/wait", "/unix"]
             else:
                 log("Executable is inside wine prefix, launching normally.")
                 argv = [g_proton.wine64_bin]


### PR DESCRIPTION
Use the fully qualified path to `start.exe` so avoid WIne tripping if any Windows compatible targets exist in the current working directory named `start`. Filenames that cause issues include `start.exe`, `start.bat`, `start.com` etc.

I also included the `/wait` switch to wait on the process. I have not experienced any weirdness with it on `proton-cachyos` and nobody has reported an issue that can be attributed to it, so let's hope it's fine.