### PR TITLE
patches: Add fix for GTA V Enhanced crashing upon startup

### DIFF
--- a/patches/game-patches/gtav-enhanced-crashfix.patch
+++ b/patches/game-patches/gtav-enhanced-crashfix.patch
@@ -1,0 +1,45 @@
+From a93623eced47efd4544ca334f9de373e2d529a1c Mon Sep 17 00:00:00 2001
+From: Alistair Leslie-Hughes <leslie_alistair@hotmail.com>
+Date: Tue, 12 Nov 2024 17:05:46 +1100
+Subject: [PATCH] user32: Implement GetDpiAwarenessContextForProcess.
+
+Wine-Bug: https://bugs.winehq.org/show_bug.cgi?id=57169
+---
+ dlls/user32/user32.spec | 1 +
+ dlls/user32/win.c       | 7 +++++++
+ 2 files changed, 8 insertions(+)
+
+diff --git a/dlls/user32/user32.spec b/dlls/user32/user32.spec
+index 87ed8f64527..56eb47c9440 100644
+--- a/dlls/user32/user32.spec
++++ b/dlls/user32/user32.spec
+@@ -299,6 +299,7 @@
+ @ stdcall GetDlgItemTextA(long long ptr long)
+ @ stdcall GetDlgItemTextW(long long ptr long)
+ @ stdcall GetDoubleClickTime() NtUserGetDoubleClickTime
++@ stdcall GetDpiAwarenessContextForProcess(ptr)
+ @ stdcall GetDpiForMonitorInternal(long long ptr ptr) NtUserGetDpiForMonitor
+ @ stdcall GetDpiForSystem()
+ @ stdcall GetDpiForWindow(long)
+
+diff --git a/dlls/user32/win.c b/dlls/user32/win.c
+index 7a552b48db4..2443ea465c5 100644
+--- a/dlls/user32/win.c
++++ b/dlls/user32/win.c
+@@ -615,6 +615,13 @@ DPI_AWARENESS_CONTEXT WINAPI GetWindowDpiAwarenessContext( HWND hwnd )
+     return LongToHandle( NtUserGetWindowDpiAwarenessContext( hwnd ) );
+ }
+ 
++/***********************************************************************
++ *		GetDpiAwarenessContextForProcess  (USER32.@)
++ */
++DPI_AWARENESS_CONTEXT WINAPI GetDpiAwarenessContextForProcess(HANDLE process)
++{
++    return LongToHandle( NtUserGetProcessDpiAwarenessContext( process ) );
++}
+ 
+ /***********************************************************************
+  *		GetWindowDpiHostingBehavior  (USER32.@)
+-- 
+GitLab
+

--- a/patches/protonprep-valve-staging.sh
+++ b/patches/protonprep-valve-staging.sh
@@ -291,6 +291,9 @@
     echo "WINE: -GAME FIXES- add __TRY/__EXCEPT_PAGE_FAULT wnsprintfA xDefiant patch because of a bad arg passed by the game that would exit to desktop"
     patch -Np1 < ../patches/game-patches/xdefiant.patch
 
+    echo "WINE: -GAME FIXES- GTA V Enhanced crash fix"
+    patch -Np1 < ../patches/game-patches/gtav-enhanced-crashfix.patch
+
 ### END GAME PATCH SECTION ###
 
 ### (2-4) WINE HOTFIX/BACKPORT SECTION ###


### PR DESCRIPTION
This PR backports the missing User32.dll function GetDpiAwarenessContextForProcess from upstream Wine, fixing crashes for GTA V's new Enhanced version. This allows the game to start without any specific environment variables and thus also enables gameplay on non-steam versions launched through umu and/or Lutris. 