### PR TITLE
Microsoft Flight Simulator 2024 SU1 needs WerRegisterCustomMetadata

### DIFF
--- a/patches/game-patches/msfs2024.patch
+++ b/patches/game-patches/msfs2024.patch
@@ -1,0 +1,105 @@
+From a20e9ded7dd39feba4eb13f3cade3a6744f3bfda Mon Sep 17 00:00:00 2001
+From: Raphael Riemann <raphael.riemann@gmail.com>
+Date: Fri, 7 Mar 2025 15:12:21 +0100
+Subject: [PATCH] kernelbase: Add WerRegisterCustomMetadata stub.
+
+Microsoft Flight Simulator 2024 needs this since SU1.
+---
+ dlls/kernel32/kernel32.spec     |  2 ++
+ dlls/kernelbase/debug.c         | 20 ++++++++++++++++++++
+ dlls/kernelbase/kernelbase.spec |  2 ++
+ include/werapi.h                |  2 ++
+ 4 files changed, 26 insertions(+)
+
+diff --git a/dlls/kernel32/kernel32.spec b/dlls/kernel32/kernel32.spec
+index 34f1090e902..79deecc9534 100644
+--- a/dlls/kernel32/kernel32.spec
++++ b/dlls/kernel32/kernel32.spec
+@@ -1624,10 +1624,12 @@
+ @ stdcall WakeAllConditionVariable(ptr) NTDLL.RtlWakeAllConditionVariable
+ @ stdcall WakeConditionVariable(ptr) NTDLL.RtlWakeConditionVariable
+ @ stdcall -import WerGetFlags(ptr ptr)
++@ stdcall -import WerRegisterCustomMetadata(wstr wstr)
+ @ stdcall -import WerRegisterFile(wstr long long)
+ @ stdcall -import WerRegisterMemoryBlock(ptr long)
+ @ stdcall -import WerRegisterRuntimeExceptionModule(wstr ptr)
+ @ stdcall -import WerSetFlags(long)
++@ stdcall -import WerUnregisterCustomMetadata(wstr)
+ @ stdcall -import WerUnregisterFile(wstr)
+ @ stdcall -import WerUnregisterMemoryBlock(ptr)
+ @ stdcall -import WerUnregisterRuntimeExceptionModule(wstr ptr)
+diff --git a/dlls/kernelbase/debug.c b/dlls/kernelbase/debug.c
+index 6423ff4573d..36e1c6af7f6 100644
+--- a/dlls/kernelbase/debug.c
++++ b/dlls/kernelbase/debug.c
+@@ -755,6 +755,16 @@ HRESULT WINAPI /* DECLSPEC_HOTPATCH */ WerGetFlags( HANDLE process, DWORD *flags
+ }
+ 
+ 
++/***********************************************************************
++ *         WerRegisterCustomMetadata  (kernelbase.@)
++ */
++HRESULT WINAPI /* DECLSPEC_HOTPATCH */ WerRegisterCustomMetadata( const WCHAR *key, const WCHAR *value )
++{
++    FIXME( "(%s, %s) stub\n", debugstr_w(key), debugstr_w(value) );
++    return S_OK;
++}
++
++
+ /***********************************************************************
+  *         WerRegisterFile   (kernelbase.@)
+  */
+@@ -796,6 +806,16 @@ HRESULT WINAPI /* DECLSPEC_HOTPATCH */ WerSetFlags( DWORD flags )
+ }
+ 
+ 
++/***********************************************************************
++ *         WerUnregisterCustomMetadata  (kernelbase.@)
++ */
++HRESULT WINAPI /* DECLSPEC_HOTPATCH */ WerUnregisterCustomMetadata( const WCHAR *key )
++{
++    FIXME( "(%s) stub\n", debugstr_w(key));
++    return S_OK;
++}
++
++
+ /***********************************************************************
+  *         WerUnregisterFile   (kernelbase.@)
+  */
+diff --git a/dlls/kernelbase/kernelbase.spec b/dlls/kernelbase/kernelbase.spec
+index 5c628b75278..3580bf74e2e 100644
+--- a/dlls/kernelbase/kernelbase.spec
++++ b/dlls/kernelbase/kernelbase.spec
+@@ -1750,10 +1750,12 @@
+ @ stdcall WakeByAddressSingle(ptr) ntdll.RtlWakeAddressSingle
+ @ stdcall WakeConditionVariable(ptr) ntdll.RtlWakeConditionVariable
+ @ stdcall WerGetFlags(ptr ptr)
++@ stdcall WerRegisterCustomMetadata(wstr wstr)
+ @ stdcall WerRegisterFile(wstr long long)
+ @ stdcall WerRegisterMemoryBlock(ptr long)
+ @ stdcall WerRegisterRuntimeExceptionModule(wstr ptr)
+ @ stdcall WerSetFlags(long)
++@ stdcall WerUnregisterCustomMetadata(wstr)
+ @ stdcall WerUnregisterFile(wstr)
+ @ stdcall WerUnregisterMemoryBlock(ptr)
+ @ stdcall WerUnregisterRuntimeExceptionModule(wstr ptr)
+diff --git a/include/werapi.h b/include/werapi.h
+index 30ba6cd9505..344cecbd814 100644
+--- a/include/werapi.h
++++ b/include/werapi.h
+@@ -175,6 +175,7 @@ typedef struct _WER_EXCEPTION_INFORMATION
+ 
+ HRESULT WINAPI WerAddExcludedApplication(PCWSTR, BOOL);
+ HRESULT WINAPI WerGetFlags(HANDLE process, DWORD *flags);
++HRESULT WINAPI WerRegisterCustomMetadata(PCWSTR key, PCWSTR value);
+ HRESULT WINAPI WerRegisterFile(PCWSTR file, WER_REGISTER_FILE_TYPE regfiletype, DWORD flags);
+ HRESULT WINAPI WerRegisterMemoryBlock(void *block, DWORD size);
+ HRESULT WINAPI WerRegisterRuntimeExceptionModule(PCWSTR callbackdll, void *context);
+@@ -186,6 +187,7 @@ HRESULT WINAPI WerReportSetParameter(HREPORT, DWORD, PCWSTR, PCWSTR);
+ HRESULT WINAPI WerReportSetUIOption(HREPORT, WER_REPORT_UI, PCWSTR);
+ HRESULT WINAPI WerReportSubmit(HREPORT, WER_CONSENT, DWORD, PWER_SUBMIT_RESULT);
+ HRESULT WINAPI WerSetFlags(DWORD flags);
++HRESULT WINAPI WerUnregisterCustomMetadata(PCWSTR key);
+ HRESULT WINAPI WerUnregisterFile(PCWSTR file);
+ HRESULT WINAPI WerUnregisterMemoryBlock(void *block);
+ HRESULT WINAPI WerUnregisterRuntimeExceptionModule(PCWSTR callbackdll, void *context);

--- a/patches/protonprep-valve-staging.sh
+++ b/patches/protonprep-valve-staging.sh
@@ -290,6 +290,9 @@
 
     echo "WINE: -GAME FIXES- add __TRY/__EXCEPT_PAGE_FAULT wnsprintfA xDefiant patch because of a bad arg passed by the game that would exit to desktop"
     patch -Np1 < ../patches/game-patches/xdefiant.patch
+    
+    echo "WINE: -GAME FIXES- Microsoft Flight Simulator 2024 needs WerRegisterCustomMetadata since SU1"
+    patch -Np1 < ../patches/game-patches/msfs2024.patch
 
 ### END GAME PATCH SECTION ###
 


### PR DESCRIPTION
It might make sense to add this patch from Wine 10.3:
https://gitlab.winehq.org/wine/wine/-/commit/9329843456750372e771d4967190374554d20523
because the backport is super easy and it is needed to make MSFS2024 run after the mandatory SU1 update from 3 days ago.