### PR TITLE
Revert "proton: wait for process to exit when run through umu"

### DIFF
--- a/proton
+++ b/proton
@@ -1869,7 +1869,7 @@ class Session:
             log(sys.argv[2])
             if len(sys.argv) >=  3 and sys.argv[2].startswith('/'):
                 log("Executable a unix path, launching with /unix option.")
-                argv = [g_proton.wine64_bin, "c:\\windows\\system32\\start.exe", "/wait", "/unix"]
+                argv = [g_proton.wine64_bin, "c:\\windows\\system32\\start.exe", "/unix"]
             else:
                 log("Executable is inside wine prefix, launching normally.")
                 argv = [g_proton.wine64_bin]


### PR DESCRIPTION
This reverts commit b1f5af62e146f68114e5d3f19fe7e746d0aa6a24.

The `/wait` flag causes games from Epic that use `EOSBootstrapper.exe` as their executable to fail to launch. These games do launch properly if `EOSBootstrapper.exe` is substituted with their real executable, but there is no reason to complicate things.