### PR TITLE
build: install unzip to bin

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -1382,7 +1382,7 @@ PROTONFIXES_TARGET := $(addprefix $(DST_BASE)/,protonfixes)
 $(PROTONFIXES_TARGET): $(addprefix $(SRCDIR)/,protonfixes)
 
 $(OBJ)/.build-protonfixes:
-	cd $(SRCDIR)/protonfixes && make
+	cd $(SRCDIR)/protonfixes && ./build.sh
 	touch $(@)
 
 $(PROTONFIXES_TARGET): $(OBJ)/.build-protonfixes
@@ -1443,6 +1443,7 @@ redist: all
 	mkdir -p $(REDIST_DIR)
 	rsync --delete -arx $(DST_BASE)/ $(REDIST_DIR)
 	cp $(PROTONFIXES_TARGET)/cabextract $(REDIST_DIR)/files/bin/
+	cp $(PROTONFIXES_TARGET)/unzip $(REDIST_DIR)/files/bin/
 	cp -a $(PROTONFIXES_TARGET)/libmspack.so $(REDIST_DIR)/files/lib64/
 	cp -a $(PROTONFIXES_TARGET)/libmspack.so.0 $(REDIST_DIR)/files/lib64/
 	cp $(PROTONFIXES_TARGET)/libmspack.so.0.1.0 $(REDIST_DIR)/files/lib64/


### PR DESCRIPTION
unzip is unavailable in steamrt3 and some winetricks verbs can fail due to 7z.exe, resulting in fixes not being applied to games.

VERSIONS.txt:
```
#Name	Version		Runtime	Runtime_Version	Comment
depot	3.0.20250306.120299			# Overall version number
pressure-vessel	0.20250225.0	scout		# pressure-vessel-bin.tar.gz
scripts	0.20250225.0			# from steam-runtime-tools
sniper	3.0.20250306.120299	sniper	3.0.20250306.120299	# sniper_platform_3.0.20250306.120299/
```

See https://github.com/Open-Wine-Components/umu-protonfixes/pull/279 details.
