### PR TITLE
fix: ensure dosdevices subdir exists in prefix

### DIFF
--- a/proton
+++ b/proton
@@ -967,9 +967,11 @@ class CompatData:
             self.migrate_user_paths()
 
             if not file_exists(self.prefix_dir + "/dosdevices/c:", follow_symlinks=False):
+                os.makedirs(f"{self.prefix_dir}/dosdevices", exist_ok=True)
                 os.symlink("../drive_c", self.prefix_dir + "/dosdevices/c:")
 
             if not file_exists(self.prefix_dir + "/dosdevices/z:", follow_symlinks=False):
+                os.makedirs(f"{self.prefix_dir}/dosdevices", exist_ok=True)
                 os.symlink("/", self.prefix_dir + "/dosdevices/z:")
 
             # collect configuration info


### PR DESCRIPTION
The proton script can raise a FileNotFoundError in its prefix upgrade due to the `dosdevices` subdirectory not existing. Discovered this bug when looking into a broken game with GE-Proton9-27 as the compatibility tool on Steam.

Traceback:
```
 Proton: Upgrading prefix from None to GE-Proton9-27 (/home/deck/.local/share/Steam/steamapps/compatdata/2697560/)
 Traceback (most recent call last):
   File "/home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton9-27/proton", line 1924, in <module>
     g_session.init_session(sys.argv[1] != "runinprefix")
   File "/home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton9-27/proton", line 1816, in init_session
     g_compatdata.setup_prefix()
   File "/home/deck/.local/share/Steam/compatibilitytools.d/GE-Proton9-27/proton", line 970, in setup_prefix
     os.symlink("../drive_c", self.prefix_dir + "/dosdevices/c:")
 FileNotFoundError: [Errno 2] No such file or directory: '../drive_c' -> '/home/deck/.local/share/Steam/steamapps/compatdata/2697560/pfx//dosdevices/c:'
```

Link to upstream report: https://github.com/ValveSoftware/Proton/issues/8213
