### PR TITLE
build: create zstd compressed archives

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -1480,6 +1480,8 @@ redist: all
 	mv $(REDIST_DIR) $(BUILD_NAME)
 	tar -cvzf $(BUILD_NAME).tar.gz $(BUILD_NAME)
 	sha512sum $(BUILD_NAME).tar.gz > $(BUILD_NAME).sha512sum
+	tar -cvaf $(BUILD_NAME).tar.zst $(BUILD_NAME)
+	sha256sum $(BUILD_NAME).* > SHA256SUMS
 	@echo "Proton build available at $(BUILD_NAME).tar.gz"
 
 ##


### PR DESCRIPTION
The latest version of the umu-sdk will provide the zstd binary and this pull request will create a zstd compressed Proton archive after the build succeeds in addition to the gzip compressed one. It's expected that all files with the pattern `$(BUILD_NAME).*` in the `redist` target alongside the `SHA256SUMS` file are to be uploaded.