### PR TITLE
fix: add protonfixes bin to bin-wow64

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -1473,7 +1473,9 @@ redist: all
 	mkdir -p $(REDIST_DIR)
 	rsync --delete -arx $(DST_BASE)/ $(REDIST_DIR)
 	cp $(PROTONFIXES_TARGET)/cabextract $(REDIST_DIR)/files/bin/
+	ln -s ../bin/cabextract $(REDIST_DIR)/files/bin-wow64/cabextract
 	cp $(PROTONFIXES_TARGET)/unzip $(REDIST_DIR)/files/bin/
+	ln -s ../bin/unzip $(REDIST_DIR)/files/bin-wow64/unzip
 	cp -a $(PROTONFIXES_TARGET)/libmspack.so $(REDIST_DIR)/files/lib/x86_64-linux-gnu/
 	cp -a $(PROTONFIXES_TARGET)/libmspack.so.0 $(REDIST_DIR)/files/lib/x86_64-linux-gnu/
 	cp $(PROTONFIXES_TARGET)/libmspack.so.0.1.0 $(REDIST_DIR)/files/lib/x86_64-linux-gnu/


### PR DESCRIPTION
winetricks will fail running verbs that require the unzip binary for extraction if [wow64 is enabled by the user because the binary will not exist in PATH](https://github.com/GloriousEggroll/proton-ge-custom/blob/2146f1fbe016e31b6f39072b4cd2516ccf02dd77/proton#L649). 

Traceback:
```
Proton: Upgrading prefix from None to GE-Proton10-1 (/home/foo/Games/umu/umu-default/)
Proton: Running winetricks verbs in prefix: xaudio29
Downloading https://globalcdn.nuget.org/packages/microsoft.xaudio2.redist.1.2.11.nupkg to /home/foo/.cache/winetricks/xaudio29
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 13.8M  100 13.8M    0     0  11.3M      0  0:00:01  0:00:01 --:--:-- 11.3M
Downloading https://www.7-zip.org/a/7z2409-x64.exe to /home/foo/.cache/winetricks/7zip
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   154  100   154    0     0    198      0 --:--:-- --:--:-- --:--:--   198
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100 1598k  100 1598k    0     0  1113k      0  0:00:01  0:00:01 --:--:-- 1113k
fsync: up and running.
wine: failed to open "C:\\Program Files (x86)\\7-Zip\\7z.exe": c0000135
```

To handle this case, unzip and other protonfixes binaries need to be in `bin-wow64`.
