### PR TITLE
build: prefer make instead of build.sh

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -1412,7 +1412,7 @@ PROTONFIXES_TARGET := $(addprefix $(DST_BASE)/,protonfixes)
 $(PROTONFIXES_TARGET): $(addprefix $(SRCDIR)/,protonfixes)
 
 $(OBJ)/.build-protonfixes:
-	cd $(SRCDIR)/protonfixes && ./build.sh
+	cd $(SRCDIR)/protonfixes && make
 	touch $(@)
 
 $(PROTONFIXES_TARGET): $(OBJ)/.build-protonfixes


### PR DESCRIPTION
Invoking build.sh for protonfixes is unnecessary because `DEB_BUILD_MAINT_OPTIONS=hardening=-format` is no longer set and the build flags for unzip has changed since commit https://github.com/Open-Wine-Components/umu-protonfixes/commit/82fcd13ef0812cdef009678876312142a0cdbe37.
