### PR TITLE
patches: Add patch for fix joystick detection without an axis

### DIFF
--- a/patches/protonprep-valve-staging.sh
+++ b/patches/protonprep-valve-staging.sh
@@ -362,6 +362,8 @@
     patch -Np1 < ../patches/wine-hotfixes/pending/wine-wayland/cursor_and_launchers/0008-winewayland-Use-unaccelerated-relative-motion.patch
     patch -Np1 < ../patches/wine-hotfixes/pending/wine-wayland/cursor_and_launchers/0009-winewayland-Use-discrete-event-when-possible.patch
 
+    # Fix for joystick without axis
+    patch -Np1 < ../patches/wine-hotfixes/pending/winebus-joystick-no-axis-detection.patch
     popd
 
 ### END PROTON-GE ADDITIONAL CUSTOM PATCHES ###

--- a/patches/wine-hotfixes/pending/winebus-joystick-no-axis-detection.patch
+++ b/patches/wine-hotfixes/pending/winebus-joystick-no-axis-detection.patch
@@ -1,0 +1,36 @@
+From a408ab6ecb6309589423e58e63efa4fd28a0da6a Mon Sep 17 00:00:00 2001
+From: Makarenko Oleg <oleg@makarenk.ooo>
+Date: Tue, 20 May 2025 03:54:36 +0300
+Subject: [PATCH] winebus: Fix detection of devices with no axis.
+
+---
+ dlls/winebus.sys/bus_sdl.c | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/dlls/winebus.sys/bus_sdl.c b/dlls/winebus.sys/bus_sdl.c
+index eee95e213c0..5cec049a845 100644
+--- a/dlls/winebus.sys/bus_sdl.c
++++ b/dlls/winebus.sys/bus_sdl.c
+@@ -999,7 +999,8 @@ static void sdl_add_device(unsigned int index)
+         desc.is_gamepad = (axis_count == 6  && button_count >= 14);
+     }
+ 
+-    for (axis_offset = 0; axis_offset < axis_count; axis_offset += (options.split_controllers ? 6 : axis_count))
++    axis_offset = 0;
++    do
+     {
+         NTSTATUS status;
+ 
+@@ -1026,7 +1027,9 @@ static void sdl_add_device(unsigned int index)
+         }
+ 
+         bus_event_queue_device_created(&event_queue, &impl->unix_device, &desc);
++        axis_offset += (options.split_controllers ? 6 : axis_count);
+     }
++    while (axis_offset < axis_count);
+ }
+ 
+ static void process_device_event(SDL_Event *event)
+-- 
+GitLab
+


### PR DESCRIPTION
Currently Wine does not detect joysticks without an axis. This is a bug, and affects devices like shifters and button-boxes for racing/flying sim titles. This patch fixes it and restores that functionality.

This is already merged into upstream Wine, but it could take some time before Valve picks it up. It would be great if it was included here.
https://gitlab.winehq.org/wine/wine/-/merge_requests/8088
