### PR TITLE
Backport specific bits to implement Windows quirks for anti-cheat engines

### DIFF
--- a/.github/patches/0001-build-strip-binaries-early.patch
+++ b/.github/patches/0001-build-strip-binaries-early.patch
@@ -1,0 +1,25 @@
+From 8668d576addb03a5a41230925a4aa4558fa13b46 Mon Sep 17 00:00:00 2001
+From: Stelios Tsampas <loathingkernel@gmail.com>
+Date: Tue, 19 Mar 2024 14:20:43 +0200
+Subject: [PATCH] build: strip binaries early
+
+---
+ Makefile.in | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/Makefile.in b/Makefile.in
+index f1b3a18c..2a23031a 100644
+--- a/Makefile.in
++++ b/Makefile.in
+@@ -58,7 +58,7 @@ i386_CFLAGS    := -mstackrealign $(HOST_CFLAGS) -mno-avx512f -mfpmath=sse
+ x86_64_CFLAGS  := -mcmodel=small $(HOST_CFLAGS) -mno-avx512f -mfpmath=sse
+ 
+ CFLAGS  = -O2 -fwrapv -fno-strict-aliasing
+-CFLAGS += -ggdb -ffunction-sections -fdata-sections -fno-omit-frame-pointer
++CFLAGS += -s -ffunction-sections -fdata-sections -fno-omit-frame-pointer
+ CFLAGS += -ffile-prefix-map=$(CCACHE_BASEDIR)=.
+ 
+ ifneq ($(SUPPRESS_WARNINGS),)
+-- 
+2.49.0
+

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
     - name: Patch
       run: |
         # strip binaries at compile time to save space in the runner
-        patch -Np1 -i ./.github/patches/0001-strip-binaries-early.patch
+        patch -Np1 -i ./.github/patches/0001-build-strip-binaries-early.patch
         # apply proton-ge-custom patches
         ./patches/protonprep-valve-staging.sh || true
         mkdir ./build

--- a/patches/protonprep-valve-staging.sh
+++ b/patches/protonprep-valve-staging.sh
@@ -372,6 +372,14 @@
     patch -Np1 < ../patches/wine-hotfixes/pending/wine-wayland/0076-winewayland-add-opcode-3-of-zwlr_data_control_device.patch
     patch -Np1 < ../patches/wine-hotfixes/pending/wine-wayland/0077-winewayland-systray-skeleton.patch
     patch -Np1 < ../patches/wine-hotfixes/pending/wine-wayland/0078-fixup-HACK-winewayland-Send-relative-event-with-abso.patch
+
+    echo "WINE: -CUSTOM- General fixes to help meet certain Anti-cheat engines' requirements"
+    # https://gitlab.winehq.org/wine/wine-staging/-/commit/d88d44f1d9d94cb11aff9e2f0ce37d0d67fe1e95
+    patch -Np1 < ../patches/wine-hotfixes/staging/trap-syscalls-in-reserved-area/0001-ntdll-Also-trap-syscalls-in-the-top-down-reserved-ar.patch
+    # https://gitlab.winehq.org/wine/wine/-/merge_requests/7579
+    patch -Np1 < ../patches/wine-hotfixes/pending/ntdll-return-access-violation-if-address-not-writable.patch
+    # https://gitlab.winehq.org/wine/wine/-/merge_requests/8324
+    patch -Np1 < ../patches/wine-hotfixes/pending/kernelbase-allocate-new-buffer-for-module-name.patch
     popd
 
 ### END PROTON-GE ADDITIONAL CUSTOM PATCHES ###

--- a/patches/wine-hotfixes/pending/kernelbase-allocate-new-buffer-for-module-name.patch
+++ b/patches/wine-hotfixes/pending/kernelbase-allocate-new-buffer-for-module-name.patch
@@ -1,0 +1,36 @@
+From 29acfe532adda7aef34b8cd0c74f32d9f89dd0bb Mon Sep 17 00:00:00 2001
+From: Dylan Donnell <dylan.donnell@student.griffith.ie>
+Date: Sun, 15 Jun 2025 00:23:39 +0300
+Subject: [PATCH] kernelbase: Made LoadLibraryExA allocate a new buffer for the
+ module name.
+
+---
+ dlls/kernelbase/loader.c | 11 +++++++++--
+ 1 file changed, 9 insertions(+), 2 deletions(-)
+
+diff --git a/dlls/kernelbase/loader.c b/dlls/kernelbase/loader.c
+index 7afbe0460eb..6d651b0cc9f 100644
+--- a/dlls/kernelbase/loader.c
++++ b/dlls/kernelbase/loader.c
+@@ -533,9 +533,16 @@ HMODULE WINAPI DECLSPEC_HOTPATCH LoadLibraryW( LPCWSTR name )
+ HMODULE WINAPI DECLSPEC_HOTPATCH LoadLibraryExA( LPCSTR name, HANDLE file, DWORD flags )
+ {
+     WCHAR *nameW;
++    HMODULE module;
++
++    /* A new allocation is necessary due to TP Shell Service
++     * calling LoadLibraryExA from an LdrLoadDll hook */
++    if (!(nameW = file_name_AtoW( name, TRUE ))) return 0;
+ 
+-    if (!(nameW = file_name_AtoW( name, FALSE ))) return 0;
+-    return LoadLibraryExW( nameW, file, flags );
++    module = LoadLibraryExW( nameW, file, flags );
++
++    HeapFree( GetProcessHeap(), 0, nameW );
++    return module;
+ }
+ 
+ 
+-- 
+GitLab
+

--- a/patches/wine-hotfixes/pending/ntdll-return-access-violation-if-address-not-writable.patch
+++ b/patches/wine-hotfixes/pending/ntdll-return-access-violation-if-address-not-writable.patch
@@ -1,0 +1,85 @@
+From 2364128c56f58561f5204b445fa8abd8f9c56105 Mon Sep 17 00:00:00 2001
+From: Dylan Donnell <dylan.donnell@student.griffith.ie>
+Date: Fri, 14 Mar 2025 23:32:03 +0200
+Subject: [PATCH 1/2] ntdll: Return STATUS_ACCESS_VIOLATION from
+ NtQueryInformationThread ThreadHideFromDebugger if *ret_len is not writable.
+
+---
+ dlls/ntdll/unix/thread.c | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/dlls/ntdll/unix/thread.c b/dlls/ntdll/unix/thread.c
+index b64a7dd40af..d3ddcf13963 100644
+--- a/dlls/ntdll/unix/thread.c
++++ b/dlls/ntdll/unix/thread.c
+@@ -2275,6 +2275,12 @@ NTSTATUS WINAPI NtQueryInformationThread( HANDLE handle, THREADINFOCLASS class,
+         return get_thread_wow64_context( handle, data, length );
+ 
+     case ThreadHideFromDebugger:
++        /* TP Shell Service depends on ThreadHideFromDebugger returning
++         * STATUS_ACCESS_VIOLATION if *ret_len is not writable, before
++         * any other checks. Despite the status, the variable does not
++         * actually seem to be written at that time. */
++        if (ret_len) *(volatile ULONG *)ret_len |= 0;
++
+         if (length != sizeof(BOOLEAN)) return STATUS_INFO_LENGTH_MISMATCH;
+         if (!data) return STATUS_ACCESS_VIOLATION;
+         SERVER_START_REQ( get_thread_info )
+-- 
+GitLab
+
+
+From 408710e37b21da4cd1bb56f4df49f0f64e66fa5d Mon Sep 17 00:00:00 2001
+From: Dylan Donnell <dylan.donnell@student.griffith.ie>
+Date: Sat, 15 Mar 2025 00:34:23 +0200
+Subject: [PATCH 2/2] ntdll/tests: Add tests for ret_len on
+ NtQueryInformationThread HideFromDebugger.
+
+---
+ dlls/ntdll/tests/info.c | 23 ++++++++++++++++++++++-
+ 1 file changed, 22 insertions(+), 1 deletion(-)
+
+diff --git a/dlls/ntdll/tests/info.c b/dlls/ntdll/tests/info.c
+index 5003a5b50c2..d24639b6b68 100644
+--- a/dlls/ntdll/tests/info.c
++++ b/dlls/ntdll/tests/info.c
+@@ -3274,7 +3274,7 @@ static void test_HideFromDebugger(void)
+ {
+     NTSTATUS status;
+     HANDLE thread, stop_event;
+-    ULONG dummy;
++    ULONG dummy, ret_len;
+ 
+     dummy = 0;
+     status = pNtSetInformationThread( GetCurrentThread(), ThreadHideFromDebugger, &dummy, sizeof(ULONG) );
+@@ -3321,6 +3321,27 @@ static void test_HideFromDebugger(void)
+     ok( status == STATUS_SUCCESS, "got %#lx\n", status );
+     ok( dummy == 1, "Expected dummy == 1, got %08lx\n", dummy );
+ 
++    status = NtQueryInformationThread( thread, ThreadHideFromDebugger, &dummy, 1, (ULONG *)1 );
++    ok( status == STATUS_ACCESS_VIOLATION, "Expected STATUS_ACCESS_VIOLATION, got %08lx\n", status );
++
++    status = NtQueryInformationThread( thread, ThreadHideFromDebugger, &dummy, 0, (ULONG *)1 );
++    ok( status == STATUS_ACCESS_VIOLATION, "Expected STATUS_ACCESS_VIOLATION, got %08lx\n", status );
++
++    ret_len = 0xdeadbeef;
++    status = NtQueryInformationThread( thread, ThreadHideFromDebugger, &dummy, 0, &ret_len );
++    ok( status == STATUS_INFO_LENGTH_MISMATCH, "Expected STATUS_INFO_LENGTH_MISMATCH, got %#lx\n", status );
++    ok( ret_len == 0xdeadbeef, "Expected ret_len == deadbeef, got %08lx\n", ret_len );
++
++    ret_len = 0xdeadbeef;
++    status = NtQueryInformationThread( (HANDLE)0xdeadbeef, ThreadHideFromDebugger, &dummy, 1, &ret_len );
++    ok( status == STATUS_INVALID_HANDLE, "Expected STATUS_INVALID_HANDLE, got %#lx\n", status );
++    ok( ret_len == 0xdeadbeef, "Expected ret_len == deadbeef, got %08lx\n", ret_len );
++
++    ret_len = 0xdeadbeef;
++    status = NtQueryInformationThread( thread, ThreadHideFromDebugger, &dummy, 1, &ret_len );
++    ok( status == STATUS_SUCCESS, "got %#lx\n", status );
++    ok( ret_len == 1, "Expected ret_len == 1, got %08lx\n", ret_len );
++
+     SetEvent( stop_event );
+     WaitForSingleObject( thread, INFINITE );
+     CloseHandle( thread );
+-- 
+GitLab
+

--- a/patches/wine-hotfixes/staging/trap-syscalls-in-reserved-area/0001-ntdll-Also-trap-syscalls-in-the-top-down-reserved-ar.patch
+++ b/patches/wine-hotfixes/staging/trap-syscalls-in-reserved-area/0001-ntdll-Also-trap-syscalls-in-the-top-down-reserved-ar.patch
@@ -1,0 +1,45 @@
+From 5c8ba3ac610c4ddd4cf7df9f3084a9db08a80106 Mon Sep 17 00:00:00 2001
+From: NelloKudo <marshnelloosu@gmail.com>
+Date: Wed, 18 Jun 2025 19:23:02 +0200
+Subject: [PATCH] ntdll: Also trap syscalls in the top-down reserved area
+
+Backport of wine-staging patch from "mkrsym1@gmail.com".
+https://github.com/wine-staging/wine-staging/commit/d88d44f1d9d94cb11aff9e2f0ce37d0d67fe1e95
+---
+ dlls/ntdll/unix/signal_x86_64.c | 16 ++++++++++++----
+ 1 file changed, 12 insertions(+), 4 deletions(-)
+
+diff --git a/dlls/ntdll/unix/signal_x86_64.c b/dlls/ntdll/unix/signal_x86_64.c
+index 98f3df6..e3d09e6 100644
+--- a/dlls/ntdll/unix/signal_x86_64.c
++++ b/dlls/ntdll/unix/signal_x86_64.c
+@@ -1982,14 +1982,22 @@ static void install_bpf(struct sigaction *sig_act)
+ 
+     static struct sock_filter filter[] =
+     {
+-        BPF_STMT(BPF_LD | BPF_W | BPF_ABS, offsetof(struct seccomp_data, instruction_pointer) + 4),
+-        /* Native libs are loaded at high addresses. */
+-        BPF_JUMP(BPF_JMP | BPF_JGT | BPF_K, NATIVE_SYSCALL_ADDRESS_START >> 32, 0, 1),
+-        BPF_STMT(BPF_RET | BPF_K, SECCOMP_RET_ALLOW),
+         /* Allow i386. */
+         BPF_STMT(BPF_LD | BPF_W | BPF_ABS, offsetof(struct seccomp_data, arch)),
+         BPF_JUMP (BPF_JMP | BPF_JEQ | BPF_K, AUDIT_ARCH_X86_64, 1, 0),
+         BPF_STMT(BPF_RET | BPF_K, SECCOMP_RET_ALLOW),
++        /* Native libs are loaded at high addresses. */
++        BPF_STMT(BPF_LD | BPF_W | BPF_ABS, offsetof(struct seccomp_data, instruction_pointer) + 4),
++        BPF_JUMP(BPF_JMP | BPF_JGT | BPF_K, NATIVE_SYSCALL_ADDRESS_START >> 32, 0, 8),
++        /* High addresses may be top-down allocations, trap those */
++        BPF_JUMP(BPF_JMP | BPF_JEQ | BPF_K, 0x7fff, 1, 0),
++        BPF_STMT(BPF_RET | BPF_K, SECCOMP_RET_ALLOW),
++        BPF_STMT(BPF_LD | BPF_W | BPF_ABS, offsetof(struct seccomp_data, instruction_pointer)),
++        BPF_JUMP(BPF_JMP | BPF_JGE | BPF_K, 0xfe000000, 1, 0),
++        BPF_STMT(BPF_RET | BPF_K, SECCOMP_RET_ALLOW),
++        BPF_JUMP(BPF_JMP | BPF_JGE | BPF_K, 0xffff0000, 0, 1),
++        BPF_STMT(BPF_RET | BPF_K, SECCOMP_RET_ALLOW),
++        BPF_STMT(BPF_RET | BPF_K, SECCOMP_RET_TRAP),
+         /* Allow wine64-preloader */
+         BPF_STMT(BPF_LD | BPF_W | BPF_ABS, offsetof(struct seccomp_data, instruction_pointer)),
+         BPF_JUMP(BPF_JMP | BPF_JGE | BPF_K, 0x7d400000, 1, 0),
+-- 
+2.49.0
+


### PR DESCRIPTION
Based on @NelloKudo's [original branch](https://github.com/NelloKudo/proton-cachyos) original testing branch. Patches moved and re-named to match expected (assumed) style guidelines.

Added updated cachy patch to get the Github automata back online.