### PR TITLE
Use wide characters in vgsoh.patch

### DIFF
--- a/patches/game-patches/vgsoh.patch
+++ b/patches/game-patches/vgsoh.patch
@@ -6,8 +6,8 @@ index f4f9d14518f..69005607224 100644
  {
      UNICODE_STRING dirW;
  
-+    char str[MAX_PATH];
-+    DWORD size = GetEnvironmentVariableA(L"SteamGameId", str, sizeof(str));
++    wchar_t str[MAX_PATH];
++    DWORD size = GetEnvironmentVariableW(L"SteamGameId", str, MAX_PATH);
 +
 +    if (size > 0) {
 +        if (wcscmp(str, L"218210") == 0) {


### PR DESCRIPTION
This fixes the following compile errors with GCC 15.1

```
dlls/kernelbase/file.c: In function ‘SetCurrentDirectoryW’: dlls/kernelbase/file.c:2881:42: error: passing argument 1 of ‘GetEnvironmentVariableA’ from incompatible pointer type [-Wincompatible-pointer-types]
 2881 |     DWORD size = GetEnvironmentVariableA(L"SteamGameId", str, sizeof(str));
      |                                          ^~~~~~~~~~~~~~
      |                                          |
      |                                          const short unsigned int *
In file included from dlls/kernelbase/file.c:30:
include/winbase.h:2227:55: note: expected ‘LPCSTR’ {aka ‘const char *’} but argument is of type ‘const short unsigned int *’
 2227 | WINBASEAPI DWORD       WINAPI GetEnvironmentVariableA(LPCSTR,LPSTR,DWORD);
      |                                                       ^~~~~~
In file included from include/windef.h:262,
                 from dlls/kernelbase/file.c:29:
include/winnt.h:528:38: note: ‘LPCSTR’ declared here
  528 | typedef const CHAR     *PCSTR,      *LPCSTR;
      |                                      ^~~~~~
dlls/kernelbase/file.c:2884:20: error: passing argument 1 of ‘wcscmp’ from incompatible pointer type [-Wincompatible-pointer-types]
 2884 |         if (wcscmp(str, L"218210") == 0) {
      |                    ^~~
      |                    |
      |                    char *
In file included from include/msvcrt/string.h:12,
                 from include/winnt.h:32:
include/msvcrt/corecrt_wstring.h:57:34: note: expected ‘const wchar_t *’ {aka ‘const short unsigned int *’} but argument is of type ‘char *’
   57 | _ACRTIMP int      __cdecl wcscmp(const wchar_t*,const wchar_t*);
      |                                  ^~~~~~~~~~~~~~
```