### PR TITLE
patches: add RegGetValueW fix

### DIFF
--- a/patches/protonprep-valve-staging.sh
+++ b/patches/protonprep-valve-staging.sh
@@ -247,6 +247,10 @@
     echo "WINE: -PENDING- unity crash hotfix"
     patch -Np1 < ../patches/wine-hotfixes/pending/unity_crash_hotfix.patch
 
+    # https://bugs.winehq.org/show_bug.cgi?id=58476
+    echo "WINE: -PENDING- RegGetValueW dwFlags hotfix (R.E.A.L VR mod)"
+    patch -Np1 < ../patches/wine-hotfixes/pending/registry_RRF_RT_REG_SZ-RRF_RT_REG_EXPAND_SZ.patch
+
     # https://github.com/ValveSoftware/wine/pull/205
     # https://github.com/ValveSoftware/Proton/issues/4625
     echo "WINE: -PENDING- Add WINE_DISABLE_SFN option. (Yakuza 5 cutscenes fix)"

--- a/patches/wine-hotfixes/pending/registry_RRF_RT_REG_SZ-RRF_RT_REG_EXPAND_SZ.patch
+++ b/patches/wine-hotfixes/pending/registry_RRF_RT_REG_SZ-RRF_RT_REG_EXPAND_SZ.patch
@@ -1,0 +1,25 @@
+diff --git a/dlls/kernelbase/registry.c b/dlls/kernelbase/registry.c
+index 7908501..ad6a981 100644
+--- a/dlls/kernelbase/registry.c
++++ b/dlls/kernelbase/registry.c
+@@ -1914,10 +1914,6 @@ LSTATUS WINAPI RegGetValueW( HKEY hKey, LPCWSTR pszSubKey, LPCWSTR pszValue,
+     if (pvData && !pcbData)
+         return ERROR_INVALID_PARAMETER;
+ 
+-    if ((dwFlags & RRF_RT_REG_EXPAND_SZ) && !(dwFlags & RRF_NOEXPAND) &&
+-            ((dwFlags & RRF_RT_ANY) != RRF_RT_ANY))
+-        return ERROR_INVALID_PARAMETER;
+-
+     if ((dwFlags & RRF_WOW64_MASK) == RRF_WOW64_MASK)
+         return ERROR_INVALID_PARAMETER;
+ 
+@@ -1933,6 +1929,9 @@ LSTATUS WINAPI RegGetValueW( HKEY hKey, LPCWSTR pszSubKey, LPCWSTR pszValue,
+     }
+ 
+     ret = RegQueryValueExW(hKey, pszValue, NULL, &dwType, pvData, &cbData);
++    if ((dwFlags & RRF_RT_REG_EXPAND_SZ) && !(dwFlags & RRF_NOEXPAND) &&
++            ((dwFlags & RRF_RT_ANY) != RRF_RT_ANY) && (dwFlags & dwType))
++        return ERROR_INVALID_PARAMETER;
+ 
+     /* If the value is a string, we need to read in the whole value to be able
+      * to know exactly how many bytes are needed after expanding the string and


### PR DESCRIPTION
Per https://bugs.winehq.org/show_bug.cgi?id=58476, this patch makes Wine's implementation of RegGetValueW work as in Windows.

This allows the R.E.A.L VR mod (in my case for Cyberpunk 2077) to work properly over OpenXR, but likely fixes other fiddly bugs for other applications querying the registry in this fashion.

Seems to comply with https://learn.microsoft.com/en-us/windows/win32/api/winreg/nf-winreg-reggetvaluew API docs based on minutes of strenuous testing.