### PR TITLE
proton: import protonfixes at the top-level imports

### DIFF
--- a/proton
+++ b/proton
@@ -40,6 +40,8 @@ from filelock import FileLock
 from random import randrange
 from pathlib import Path
 
+import protonfixes
+
 #To enable debug logging, copy "user_settings.sample.py" to "user_settings.py"
 #and edit it if needed.
 
@@ -2159,7 +2161,6 @@ if __name__ == "__main__":
 
     g_session.init_session(sys.argv[1] != "runinprefix")
 
-    import protonfixes
     protonfixes.setup(g_session.env, "PATH", ld_path_var, prepend_to_env_str)
     protonfixes.setup_mount_drives(setup_dir_drive)
     protonfixes.winetricks(g_session.env, g_proton.wine_bin, g_proton.wineserver_bin)


### PR DESCRIPTION
After moving the functions to protofixes here https://github.com/Open-Wine-Components/umu-protonfixes/pull/324 `PROTON_DLL_COPY` is set when importing the `protonfixe`s module. By importing it late, it's not in effect when `g_session.init_session()` is run. I should have been clearer that the order matters in the example usage https://github.com/Open-Wine-Components/umu-protonfixes/pull/324#issuecomment-2888600074 as I also made the same mistake in `proton-cachyos` 


Maybe fixes: GloriousEggroll/proton-ge-custom#194
