### PR TITLE
Update workflow with automated release

### DIFF
--- a/.github/workflows/_job_build.yml
+++ b/.github/workflows/_job_build.yml
@@ -1,4 +1,4 @@
-name: Build
+name: _job_build
 
 on:
   workflow_call:

--- a/.github/workflows/_job_upload.yml
+++ b/.github/workflows/_job_upload.yml
@@ -1,0 +1,39 @@
+name: _job_upload
+
+on:
+  workflow_call:
+    inputs:
+      version:
+        required: true
+        type: string
+      name:
+        required: true
+        type: string
+
+jobs:
+  upload:
+    name: Upload ${{ inputs.name }}
+    strategy:
+      matrix:
+        include:
+          - file: ${{ inputs.name }}.tar.gz
+          - file: ${{ inputs.name }}.tar.zst
+          - file: ${{ inputs.name }}.sha512sum
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download ${{ matrix.file }} artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ matrix.file }}
+
+      - name: Upload ${{ matrix.file }} to release
+        shell: bash
+        run: >-
+          gh
+          --repo "${{ github.server_url }}/${{ github.repository }}"
+          release upload
+          ${{ inputs.version }}
+          ${{ matrix.file }}
+          --clobber
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,15 +9,15 @@ on:
 
 jobs:
   proton:
-    name: ${{ inputs.name }}
+    name: Build ${{ inputs.name }}
     runs-on: ubuntu-latest
     steps:
     - name: Prepare host
       run: sudo apt update && sudo apt-get install -y ccache fontforge-nox
 
-    - name: Restore Cache
+    - name: Restore cache
+      id: ccache-restore
       uses: actions/cache/restore@v4
-      id: restore-cache
       with:
         path: ~/.ccache
         key: ccache-proton-${{ github.run_id }}
@@ -42,18 +42,21 @@ jobs:
 
     - name: Configure
       working-directory: ./build
-      run: ../configure.sh --build-name=${{ inputs.name }} --container-engine=docker
+      run: |
+        ../configure.sh --build-name=${{ inputs.name }} --container-engine=docker
 
     - name: Make ${{ inputs.name }}
       working-directory: ./build
-      run: make -j3 redist
+      run: |
+        make -j$(nproc) redist
 
-    - name: Always Save Cache
+    - name: Save cache
+      id: ccache-save
+      if: always()
       uses: actions/cache/save@v4
-      if: always() && steps.restore-cache.outputs.cache-hit != 'true'
       with:
         path: ~/.ccache
-        key: ${{ steps.restore-cache.outputs.cache-primary-key }}
+        key: ${{ steps.ccache-restore.outputs.cache-primary-key }}
 
     - name: Upload artifact ${{ inputs.name }}.tar.gz
       uses: actions/upload-artifact@v4
@@ -72,3 +75,4 @@ jobs:
       with:
         name: ${{ inputs.name }}.sha512sum
         path: ./build/${{ inputs.name }}.sha512sum
+

--- a/.github/workflows/devel.yml
+++ b/.github/workflows/devel.yml
@@ -1,7 +1,10 @@
 name: Development
 
-on:
-  workflow_dispatch:
+on: workflow_dispatch
+
+concurrency:
+  group: ${{ github.ref_name }}
+  cancel-in-progress: true
 
 jobs:
   version:
@@ -32,10 +35,9 @@ jobs:
         echo "branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_OUTPUT
 
   build:
-    needs: version
     name: Build
-    uses: ./.github/workflows/build.yml
+    needs: version
+    uses: ./.github/workflows/_job_build.yml
     with:
       name: ${{ needs.version.outputs.full_desc }}-${{ needs.version.outputs.branch }}
-
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,33 +3,53 @@ name: Release
 on:
   release:
     types: [ published ]
+  push:
+    tags:
+      - 'GE-Proton*-*'
+
+concurrency:
+  group: ${{ github.ref_name }}
+  cancel-in-progress: true
 
 jobs:
   build:
     name: Build
-    uses: ./.github/workflows/build.yml
+    uses: ./.github/workflows/_job_build.yml
     with:
       name: ${{ github.ref_name }}
 
   release:
-    name: Release ${{ github.ref_name }}
+    name: Release
     needs: build
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
     steps:
-    - name: Download ${{ github.ref_name }}.tar.gz artifact
-      uses: actions/download-artifact@v4
+    - uses: actions/checkout@v4
       with:
-        name: ${{ github.ref_name }}.tar.gz
-
-    - name: Download ${{ github.ref_name }}.sha512sum artifact
-      uses: actions/download-artifact@v4
-      with:
-        name: ${{ github.ref_name }}.sha512sum
-
-    - name: Upload ${{ github.ref_name }}.{tar.gz,sha512sum} to release
+        fetch-depth: 0
+        fetch-tags: true
+    - name: Create
+      id: create
+      shell: bash
+      run: >-
+        gh
+        --repo "${{ github.server_url }}/${{ github.repository }}"
+        release create
+        ${{ github.ref_name }}
+        --latest
+        --title "${{ github.ref_name }} Released"
+        --notes-from-tag
+        --verify-tag
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run:
-        gh -R ${{ github.repositoryUrl }} release upload ${{ github.ref_name }} ${{ github.ref_name }}.{tar.gz,sha512sum}
+
+  upload:
+    name: Upload
+    needs: release
+    strategy:
+      matrix:
+        include:
+          - name: ${{ github.ref_name }}
+    uses: ./.github/workflows/_job_upload.yml
+    with:
+      version: ${{ github.ref_name }}
+      name: ${{ matrix.name }}


### PR DESCRIPTION
- **workflows: update build.yml**
- **workflows: update workflow to create a release automatically**

The release workflow will run automatically when a new tag is pushed, the tag has to match `GE-Proton*-*`

For release notes:
* Create an annotated release tag with `git tag -a -s <tag>` and add the release notes as the tag's commit message.
* Push the annotated tag after pushing the `master` branch.
* Pushing a forced update of the tag will cancel the workflow and start a new one.
* A release will automatically be created once the build has succeeded and will be populated with the release notes from the annotated tag that triggered it.

Draft while testing the workflow here: https://github.com/loathingKernel/Proton/actions/runs/17263924889

