### PR TITLE
Create silence-starcitizen-unsupported-os.patch

### DIFF
--- a/patches/game-patches/wine/silence-starcitizen-unsupported-os.patch
+++ b/patches/game-patches/wine/silence-starcitizen-unsupported-os.patch
@@ -1,0 +1,22 @@
+diff --git a/dlls/user32/msgbox.c b/dlls/user32/msgbox.c
+index 8d9adce..3ae5e23 100644
+--- a/dlls/user32/msgbox.c
++++ b/dlls/user32/msgbox.c
+@@ -495,6 +495,7 @@ INT WINAPI MessageBoxW( HWND hwnd, LPCWSTR text, LPCWSTR title, UINT type )
+     return MessageBoxExW(hwnd, text, title, type, LANG_NEUTRAL);
+ }
+ 
++const char *sc_unsupported = "You're trying to run the game on an unsupported Windows OS. This will likely result in undefined behavior.";
+ 
+ /**************************************************************************
+  *		MessageBoxExA (USER32.@)
+@@ -504,6 +505,9 @@ INT WINAPI MessageBoxExA( HWND hWnd, LPCSTR text, LPCSTR title,
+ {
+     MSGBOXPARAMSA msgbox;
+ 
++    if (strcmp(title, "Star Citizen") == 0 && strcmp(text, sc_unsupported) == 0)
++            return 0;
++
+     msgbox.cbSize = sizeof(msgbox);
+     msgbox.hwndOwner = hWnd;
+     msgbox.hInstance = 0;


### PR DESCRIPTION
No matter which OS you select in winecfg Star Citizen always complains about it being an unsupported Windows OS. This silences that pop up. 

Original patch by [mactan-sc](https://github.com/starcitizen-lug/patches/commits?author=mactan-sc) posted to the [star citizen lug](https://github.com/starcitizen-lug/patches/blob/main/wine/silence-sc-unsupported-os.patch).