### PR TITLE
Fix typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Full patches can be viewed in [protonprep-valve-staging.sh](patches/protonprep-v
 
 PLEASE NOTE: There are prerequisites for using this version of proton:
 
-1. You must have the proper Vulkan drivers/packages installed on your system. VKD3D on AMD requires Mesa 22.0.0 or higher for the VK_KHR_dynamic_rendering extension. Check [here ](https://github.com/lutris/docs/blob/master/InstallingDrivers.md) for general driver installation guidance.
+1. You must have the proper Vulkan drivers/packages installed on your system. VKD3D on AMD requires Mesa 22.0.0 or higher for the VK_KHR_dynamic_rendering extension. Check [here](https://github.com/lutris/docs/blob/master/InstallingDrivers.md) for general driver installation guidance.
 
 ### Manual
 


### PR DESCRIPTION
This way, the space after "here" won't be underlined / part of the link.