### PR TITLE
proton.py: update current prefix version to latest (fixes #337)

### DIFF
--- a/proton
+++ b/proton
@@ -45,7 +45,7 @@ import protonfixes
 #To enable debug logging, copy "user_settings.sample.py" to "user_settings.py"
 #and edit it if needed.
 
-CURRENT_PREFIX_VERSION="GE-Proton10-23"
+CURRENT_PREFIX_VERSION="GE-Proton10-24"
 
 PFX="Proton: "
 ld_path_var = "LD_LIBRARY_PATH"


### PR DESCRIPTION
Fixes #337

Manually update the version in the `proton` python script file to the latest release `GE-Proton10-24`.
I've check if there's any build files that might update  `CURRENT_PREFIX_VERSION` automatically, but couldn't find any. 