### PR TITLE
Update Readme to fix wrong Build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ This unofficial build isn't supported by GloriousEggroll nor Valve and wasn't te
 1. Clone this repository by executing:
 
 ```sh
-git clone --recurse-submodules http://github.com/gloriouseggroll/proton-ge-custom
+git clone --recurse-submodules https://github.com/gloriouseggroll/proton-ge-custom
 ```
 
 2. Drop any custom patches into patches/, then open patches/protonprep-valve-staging.sh and add a patch line for them under `#WINE CUSTOM PATCHES` in the same way the others are done.
@@ -329,7 +329,7 @@ sudo modprobe ntsync
 1. Clone this repo by executing:
 
 ```sh
-git clone --recurse-submodules http://github.com/gloriouseggroll/proton-ge-custom
+git clone --recurse-submodules https://github.com/gloriouseggroll/proton-ge-custom
 ```
 After this, a device `/dev/ntsync` should now exist on your system.
 


### PR DESCRIPTION
README uses http urls for clone, and that fails without a clear error message, changing to https fixes this and makes cloning the repository successful.