### PR TITLE
Attempt to enable arm64 builds

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -1704,7 +1704,7 @@ redist: all
 	mv $(REDIST_DIR) $(BUILD_NAME)
 	tar -cvzf $(BUILD_NAME).tar.gz $(BUILD_NAME)
 	sha512sum $(BUILD_NAME).tar.gz > $(BUILD_NAME).sha512sum
-	tar -cvaf $(BUILD_NAME).tar.zst $(BUILD_NAME)
+#	tar -cvaf $(BUILD_NAME).tar.zst $(BUILD_NAME)
 	sha256sum $(BUILD_NAME).* > SHA256SUMS
 	@echo "Proton build available at $(BUILD_NAME).tar.gz"
 


### PR DESCRIPTION
Fixing problems as they come for now, I think most are due to different assumptions between Proton-GE and upstream.

Issues:

- [ ] Makefile issue in protonfixes (https://github.com/Open-Wine-Components/umu-protonfixes/pull/493)
- [ ] Wine build issues that seem to come from Valve patches
- [ ] Lack of libSDL2-2.0.so.0 in arm64 builder
- [ ] Lack of zstd in arm64 builder

As I understand it, Proton-GE has a dedicated container for its builds that is different from the upstream's. I think the best course of action would be to create an arm64 one.