### PR TITLE
Top channels for winealsa downmixer

### DIFF
--- a/patches/protonprep-valve-staging.sh
+++ b/patches/protonprep-valve-staging.sh
@@ -282,9 +282,6 @@ apply_all_in_dir() {
 
 ### (2-7) PROTON-GE ADDITIONAL CUSTOM PATCHES ###
 
-    echo "WINE: Add an env variable to enable fast polling in winepulse"
-    apply_patch "../patches/proton/winepulse-fast-polling.patch"
-
     echo "WINE: Add an env variable to override channel count in winealsa"
     apply_patch "../patches/proton/winealsa-override-channel-count.patch"
     


### PR DESCRIPTION
winealsa:
Discussed in PipeWire IRC, there doesn't appear to be a particular reason why top channels aren't included, so I added them to my winealsa downmixer.

