### PR TITLE
patches: add libxess_dx11 redirection patch

### DIFF
--- a/patches/protonprep-valve-staging.sh
+++ b/patches/protonprep-valve-staging.sh
@@ -275,6 +275,7 @@ apply_all_in_dir() {
     #https://github.com/Open-Wine-Components/umu-protonfixes/pull/370#issuecomment-3368898328
     echo "WINE: -PENDING- add nvidia DLSS upgrade patch"
     apply_patch "../patches/wine-hotfixes/pending/0001-HACK-kernelbase-allow-overriding-dlls-for-DLSS-XeSS-.patch"
+    apply_patch "../patches/wine-hotfixes/pending/0002-HACK-kernelbase-add-redirection-for-libxess_dx11.dll.patch"
 
 
 ### END WINE PENDING UPSTREAM SECTION ###

--- a/patches/wine-hotfixes/pending/0002-HACK-kernelbase-add-redirection-for-libxess_dx11.dll.patch
+++ b/patches/wine-hotfixes/pending/0002-HACK-kernelbase-add-redirection-for-libxess_dx11.dll.patch
@@ -1,0 +1,24 @@
+From 195aacce3c32fa77946673f4574f944c51be17a1 Mon Sep 17 00:00:00 2001
+From: Stelios Tsampas <loathingkernel@gmail.com>
+Date: Mon, 5 Jan 2026 20:48:27 +0200
+Subject: [PATCH] HACK: kernelbase: add redirection for libxess_dx11.dll
+
+---
+ dlls/kernelbase/loader.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/dlls/kernelbase/loader.c b/dlls/kernelbase/loader.c
+index 66b18441344..76eb8050421 100644
+--- a/dlls/kernelbase/loader.c
++++ b/dlls/kernelbase/loader.c
+@@ -601,6 +601,7 @@ HMODULE WINAPI DECLSPEC_HOTPATCH LoadLibraryExW( LPCWSTR name, HANDLE file, DWOR
+         {
+             /* HACK: override libxe*.dll paths to a non-standard location for XeSS upgrade */
+             if (wcsstr( name, L"libxess.dll" )) wcscpy( overrideW, L"c:\\windows\\system32\\libxess.dll" );
++            if (wcsstr( name, L"libxess_dx11.dll" )) wcscpy( overrideW, L"c:\\windows\\system32\\libxess_dx11.dll" );
+             if (wcsstr( name, L"libxell.dll" )) wcscpy( overrideW, L"c:\\windows\\system32\\libxell.dll" );
+             if (wcsstr( name, L"libxess_fg.dll" )) wcscpy( overrideW, L"c:\\windows\\system32\\libxess_fg.dll" );
+         }
+-- 
+2.52.0
+


### PR DESCRIPTION
I completely forgot about making a PR about this. This completes the protonfixes addition about the same dll. There's not enough games, from my testing at least, that would require this, so there's no rush to get it out there, it's meant for completeness.