### PR TITLE
Add held_bytes throttling to the original logic in winepulse

### DIFF
--- a/patches/proton/winepulse-fast-polling.patch
+++ b/patches/proton/winepulse-fast-polling.patch
@@ -1,5 +1,5 @@
 diff --git a/dlls/winepulse.drv/pulse.c b/dlls/winepulse.drv/pulse.c
-index 85062ead684..89261aa4976 100644
+index 85062ead684..08117c4c2b0 100644
 --- a/dlls/winepulse.drv/pulse.c
 +++ b/dlls/winepulse.drv/pulse.c
 @@ -59,6 +59,21 @@ DEFINE_GUID(GUID_NULL,0,0,0,0,0,0,0,0,0,0,0);
@@ -59,7 +59,7 @@ index 85062ead684..89261aa4976 100644
      period->timer_last_time += period->period;
  
      TRACE("period %p, now %llu, timer_last_time %llu.\n", period, (long long)pa_rtclock_now(), (long long)period->timer_last_time);
-@@ -1652,20 +1670,76 @@ static void pa_streams_timer_cb(pa_mainloop_api *api, pa_time_event *e, const st
+@@ -1652,20 +1670,87 @@ static void pa_streams_timer_cb(pa_mainloop_api *api, pa_time_event *e, const st
              if (stream->dataflow == eRender)
              {
                  pulse_write(stream);
@@ -72,12 +72,7 @@ index 85062ead684..89261aa4976 100644
 +                    total_samples = stream->mmdev_period_usec * stream->ss.rate + stream->rem_samples;
 +                    adv_bytes = (total_samples / 1000000) * frame_size;
 +                    stream->rem_samples = total_samples % 1000000;
- 
--                /* regardless of what PA does, advance one period */
--                adv_bytes = min(stream->period_bytes, stream->held_bytes);
--                stream->lcl_offs_bytes += adv_bytes;
--                stream->lcl_offs_bytes %= stream->real_bufsize_bytes;
--                stream->held_bytes -= adv_bytes;
++
 +                    safe_bytes = adv_bytes;
 +
 +                    if ((stream->held_bytes > stream->pa_held_bytes))
@@ -98,8 +93,24 @@ index 85062ead684..89261aa4976 100644
 +                else
 +                {
 +                    /* --- ORIGINAL LOGIC --- */
-+                    /* regardless of what PA does, advance one period */
-+                    adv_bytes = min(stream->period_bytes, stream->held_bytes);
++                    safe_bytes = stream->period_bytes;
++
++                    if ((stream->held_bytes > stream->pa_held_bytes))
++                    {
++                        SIZE_T limit = stream->held_bytes - stream->pa_held_bytes;
++                        if (safe_bytes > limit)
++                            safe_bytes = limit;
++                    }
++                    else {
++                        safe_bytes = 0;
++                    }
+ 
+-                /* regardless of what PA does, advance one period */
+-                adv_bytes = min(stream->period_bytes, stream->held_bytes);
+-                stream->lcl_offs_bytes += adv_bytes;
+-                stream->lcl_offs_bytes %= stream->real_bufsize_bytes;
+-                stream->held_bytes -= adv_bytes;
++                    adv_bytes = safe_bytes;
 +                    stream->lcl_offs_bytes += adv_bytes;
 +                    stream->lcl_offs_bytes %= stream->real_bufsize_bytes;
 +                    stream->held_bytes -= adv_bytes;
@@ -143,7 +154,7 @@ index 85062ead684..89261aa4976 100644
      }
      pa_context_rttime_restart(pulse_ctx, e, period->timer_last_time + period->period);
  }
-@@ -1816,6 +1890,7 @@ static NTSTATUS pulse_start(void *args)
+@@ -1816,6 +1901,7 @@ static NTSTATUS pulse_start(void *args)
      {
          stream->started = TRUE;
          stream->just_started = TRUE;


### PR DESCRIPTION
My last PR (https://github.com/GloriousEggroll/proton-ge-custom/pull/434) is a variable that consists of two parts:
1. A faster polling timer
2. Tying the driver clock to the audio server clock so it can't outrun audio server and let write and read pointers overlap

The first part is a hack that should probably stay in the variable, however the second part is a mathematically correct fix that, in my opinion, should go to the original implementation.

For example
`stream->mmdev_period_usec = params->period / (get_fast_polling_override() ? 50 : 10);`
This would divide 10.(6) ms (quant 512 at 48k) by 10 and cut it a part of it off, so the fake clock of winepulse would run slightly faster which would make crackling mathematically imminent. There is more to it though, as I had pointer collisions at an integer quant, but I am not quite sure why.

Games do expect that the events can be fast (with aligned clocks), since if the padding + refill is too big, the games just stop the audio thread and wait until the next tick, so this is the expected behavior and it is exactly how winealsa operates.

One downside which I did mention in my previous PR is that wine spatialaudio tests in docker fail - There is 0 bytes of available space in the virtual hardware, so held_bytes keeps growing while pa_held_bytes does not decrease, at some point they meet and held_bytes is not allowed to decrease any more, so the tests complain. But it is absolutely necessary to avoid pointer collisions and therefore overflow (in a sense) crackles, so the tests are flawed (they do fail with winealsa too). After all, how can we tell the application we played the audio that we literally did not play?

Changing code in audio drivers is risky because if it breaks - it breaks badly, but so far my fast polling logic has been perfect in all of the real world scenarios, as in spatial audio games, WASAPI, and direct sound applications. I have personally played with it on for many hours without any issues whatsoever.
 
Something definitely needs to be done with winepulse, because audio crackles is a very common complaint which can't always be fixed with higher latency, and I believe that audio working out of the box without any troubleshooting is very important. This fix should resolve the majority of audio problems, but there also underflow issues which are probably related to low tlength/period ratio in winepulse, which, for reasons unknown to me, is very difficult to increase to the winealsa ratio.

Draft because of how delicate audio programming is, so I need your opinion on this.

