### PR TITLE
patches: Enable .exe dynamic relocation

### DIFF
--- a/patches/proton/0001-server-Dynamically-relocate-.exes-by-default-too.patch
+++ b/patches/proton/0001-server-Dynamically-relocate-.exes-by-default-too.patch
@@ -1,0 +1,39 @@
+From 2c6f018382154afbba8f60b7fe075b1d2f817fda Mon Sep 17 00:00:00 2001
+From: Jade Macho <ade@0x0a.de>
+Date: Wed, 18 Mar 2026 02:06:16 +0100
+Subject: [PATCH] server: Dynamically relocate .exes by default too
+
+TODO: Should this only be enabled for Vista onwards? Toggleable?
+---
+ dlls/ntdll/unix/virtual.c | 1 -
+ server/mapping.c          | 2 --
+ 2 files changed, 3 deletions(-)
+
+diff --git a/dlls/ntdll/unix/virtual.c b/dlls/ntdll/unix/virtual.c
+index 781598fced1..c46d2255475 100644
+--- a/dlls/ntdll/unix/virtual.c
++++ b/dlls/ntdll/unix/virtual.c
+@@ -3410,7 +3410,6 @@ static NTSTATUS virtual_map_image( HANDLE mapping, void **addr_ptr, SIZE_T *size
+     }
+ 
+     if (!image_info->map_addr &&
+-        (image_info->image_charact & IMAGE_FILE_DLL) &&
+         (image_info->image_flags & IMAGE_FLAGS_ImageDynamicallyRelocated))
+     {
+         SERVER_START_REQ( get_image_map_address )
+diff --git a/server/mapping.c b/server/mapping.c
+index 69cd0a7451b..5e742342514 100644
+--- a/server/mapping.c
++++ b/server/mapping.c
+@@ -1286,8 +1286,6 @@ static client_ptr_t assign_map_address( struct mapping *mapping )
+     struct addr_range *range = (mapping->image.base >> 32) ? &ranges64 : &ranges32;
+     mem_size_t size = round_size( mapping->size, granularity_mask );
+ 
+-    if (!(mapping->image.image_charact & IMAGE_FILE_DLL)) return 0;
+-
+     if ((ret = get_fd_map_address( mapping->fd ))) return ret;
+ 
+     size += granularity_mask + 1;  /* leave some free space between mappings */
+-- 
+2.53.0
+

--- a/patches/protonprep-valve-staging.sh
+++ b/patches/protonprep-valve-staging.sh
@@ -327,6 +327,9 @@ apply_all_in_dir() {
     echo "WINE: --CUSTOM-- add WINE_HOSTBLOCK envvar to allow working around some problematic anticheats (notably eac)"
     apply_patch "../patches/proton/wine_host_block_envvar.patch"
 
+    echo "WINE: -CUSTOM- Dynamically relocate .exes, improving compatibility with modding / hooking tools"
+    apply_patch "../patches/proton/0001-server-Dynamically-relocate-.exes-by-default-too.patch"
+
     echo "WINE: RUN AUTOCONF TOOLS/MAKE_REQUESTS"
     autoreconf -f
     ./tools/make_requests


### PR DESCRIPTION
For XIV specifically, this fixes issues with low address space being filled up by everyone and everything and, as a result, some plugins failing to apply their hooks and leaving the game in an unstable state. Beyond that, I've tested it with a handful of titles in my Steam library and it works fine.

The TODO in the patch is for upstreaming, as I'm sure a lot of people enjoyed the previous behavior where in-memory addresses were easy to understand, and I'm not sure why exes were excluded from being relocated to begin with.
