### PR TITLE
winewayland: Fix display freeze for games that fake-minimize (CryEngine/Hunt: Showdown)

### DIFF
--- a/patches/wine-hotfixes/wine-wayland/0507-winewayland-Skip-viewport-update-for-degenerate-clie.patch
+++ b/patches/wine-hotfixes/wine-wayland/0507-winewayland-Skip-viewport-update-for-degenerate-clie.patch
@@ -1,0 +1,48 @@
+From 58cefc570402a51ef3d3674af06cf5a7c1470b2c Mon Sep 17 00:00:00 2001
+From: Cwooper <cwooperm@gmail.com>
+Date: Fri, 27 Mar 2026 02:42:17 -0700
+Subject: [PATCH 507/508] winewayland: Skip viewport update for degenerate
+ client areas.
+
+Some games (e.g., CryEngine titles like Hunt: Showdown) "fake minimize"
+by moving their window to (-32000,-32000), resulting in a 0x0 client
+area. Setting the viewport to 1x1 causes the compositor to stop sending
+frame callbacks, which stalls Vulkan present indefinitely. Skip the
+viewport update entirely for degenerate client areas so the present loop
+stays alive until the app restores a valid client area.
+---
+ dlls/winewayland.drv/wayland_surface.c | 18 ++++++++++++++----
+ 1 file changed, 14 insertions(+), 4 deletions(-)
+
+diff --git a/dlls/winewayland.drv/wayland_surface.c b/dlls/winewayland.drv/wayland_surface.c
+index 88d6eab..cb59c55 100644
+--- a/dlls/winewayland.drv/wayland_surface.c
++++ b/dlls/winewayland.drv/wayland_surface.c
+@@ -797,10 +797,20 @@ static void wayland_surface_reconfigure_client(struct wayland_surface *surface,
+         wl_subsurface_place_above(client->wl_subsurface, surface->wl_surface);
+     }
+ 
+-    if (width != 0 && height != 0)
+-        wp_viewport_set_destination(client->wp_viewport, width, height);
+-    else /* We can't have a 0x0 destination, use 1x1 instead. */
+-        wp_viewport_set_destination(client->wp_viewport, 1, 1);
++    /* Some games (e.g., CryEngine) "fake minimize" by moving their window
++     * to (-32000,-32000), resulting in a degenerate 0x0 client area. Setting
++     * the viewport to 1x1 in this case causes the compositor to stop sending
++     * frame callbacks, which stalls Vulkan present indefinitely. Preserve the
++     * previous viewport configuration so that the present loop stays alive
++     * until the app restores a valid client area. */
++    if (width <= 0 || height <= 0)
++    {
++        TRACE("hwnd=%p degenerate client %dx%d, skipping viewport reconfigure\n",
++              surface->hwnd, width, height);
++        return;
++    }
++
++    wp_viewport_set_destination(client->wp_viewport, width, height);
+ 
+     wayland_resize_gl_drawable(client->hwnd);
+ }
+-- 
+2.53.0
+

--- a/patches/wine-hotfixes/wine-wayland/0508-winewayland-Handle-WS_MINIMIZE-and-restore-for-fake-.patch
+++ b/patches/wine-hotfixes/wine-wayland/0508-winewayland-Handle-WS_MINIMIZE-and-restore-for-fake-.patch
@@ -1,0 +1,111 @@
+From 1080c214fd08b8c1f279fe9ddbdafea4abff78d3 Mon Sep 17 00:00:00 2001
+From: Cwooper <cwooperm@gmail.com>
+Date: Fri, 27 Mar 2026 02:42:17 -0700
+Subject: [PATCH 508/508] winewayland: Handle WS_MINIMIZE and restore for
+ fake-minimize games.
+
+CryEngine games "fake minimize" during startup by setting WS_MINIMIZE
+and moving the window to (-32000,-32000). The Wayland driver did not
+handle this, causing it to send xdg_toplevel_unset_fullscreen which
+triggers a 0x0 configure from the compositor and freezes Vulkan present.
+
+- Detect WS_MINIMIZE and set conf->minimized so the driver calls
+  xdg_toplevel_set_minimized instead of unsetting fullscreen/maximized
+- When the compositor sends a configure while the window is at the
+  offscreen sentinel position, ack the configure and send SC_RESTORE
+  to let Win32 handle the full restore sequence
+- Save data->rects into locals before releasing the win data mutex,
+  fixing an existing use-after-release bug
+
+Fixes: GloriousEggroll/proton-ge-custom#484
+---
+ dlls/winewayland.drv/window.c | 39 ++++++++++++++++++++++++++++++++---
+ 1 file changed, 36 insertions(+), 3 deletions(-)
+
+diff --git a/dlls/winewayland.drv/window.c b/dlls/winewayland.drv/window.c
+index 4decc0f..edf4f59 100644
+--- a/dlls/winewayland.drv/window.c
++++ b/dlls/winewayland.drv/window.c
+@@ -169,6 +169,10 @@ static void wayland_win_data_get_config(struct wayland_win_data *data,
+     {
+         conf->minimized = TRUE;
+     }
++    else if (style & WS_MINIMIZE)
++    {
++        conf->minimized = TRUE;
++    }
+     /* The fullscreen state is implied by the window position and style. */
+     else if (data->is_fullscreen)
+     {
+@@ -311,12 +315,14 @@ static void wayland_surface_update_state_toplevel(struct wayland_surface *surfac
+          /* First do all state unsettings, before setting new state. Some
+           * Wayland compositors misbehave if the order is reversed. */
+         if (!(surface->window.state & WAYLAND_SURFACE_CONFIG_STATE_MAXIMIZED) &&
+-            (surface->current.state & WAYLAND_SURFACE_CONFIG_STATE_MAXIMIZED))
++            (surface->current.state & WAYLAND_SURFACE_CONFIG_STATE_MAXIMIZED) &&
++            !surface->window.minimized)
+         {
+             xdg_toplevel_unset_maximized(surface->xdg_toplevel);
+         }
+         if (!(surface->window.state & WAYLAND_SURFACE_CONFIG_STATE_FULLSCREEN) &&
+-            (surface->current.state & WAYLAND_SURFACE_CONFIG_STATE_FULLSCREEN))
++            (surface->current.state & WAYLAND_SURFACE_CONFIG_STATE_FULLSCREEN) &&
++            !surface->window.minimized)
+         {
+             xdg_toplevel_unset_fullscreen(surface->xdg_toplevel);
+             surface->requested_output = NULL;
+@@ -598,8 +604,10 @@ static void wayland_configure_window(HWND hwnd)
+     DWORD style;
+     BOOL needs_enter_size_move = FALSE;
+     BOOL needs_exit_size_move = FALSE;
++    BOOL restoring_from_minimize = FALSE;
+     struct wayland_win_data *data;
+     RECT rect;
++    LONG saved_window_left, saved_window_top;
+ 
+     if (!(data = wayland_win_data_get(hwnd))) return;
+     if (!(surface = data->wayland_surface))
+@@ -689,6 +697,31 @@ static void wayland_configure_window(HWND hwnd)
+     offset_y = ((surface->window.rect.top - surface->window.window_rect.top) +
+                 (surface->window.window_rect.bottom - surface->window.rect.bottom));
+ 
++    /* Save window position before releasing data, since data->rects may be
++     * modified by another thread after release. */
++    saved_window_left = data->rects.window.left;
++    saved_window_top = data->rects.window.top;
++
++    /* Detect restore from minimize: the window is at the offscreen sentinel
++     * position (-32000,-32000) and the compositor is sending a configure.
++     * Send SC_RESTORE to let Win32 handle the full restore sequence (clearing
++     * WS_MINIMIZE, restoring position/size, sending WM_SIZE, etc.).
++     * We must ack the configure before returning to avoid a protocol
++     * violation, then let SC_RESTORE trigger a new configure cycle. */
++    restoring_from_minimize = saved_window_left <= -30000 &&
++                              saved_window_top <= -30000;
++    if (restoring_from_minimize)
++    {
++        TRACE("hwnd=%p restoring from minimize\n", hwnd);
++        surface->current = surface->processing;
++        memset(&surface->processing, 0, sizeof(surface->processing));
++        xdg_surface_ack_configure(surface->xdg_surface,
++                                  surface->current.serial);
++        wayland_win_data_release(data);
++        send_message(hwnd, WM_SYSCOMMAND, SC_RESTORE, 0);
++        return;
++    }
++
+     wayland_win_data_release(data);
+ 
+     TRACE("processing=%dx%d,%#x\n", width, height, state);
+@@ -721,7 +754,7 @@ static void wayland_configure_window(HWND hwnd)
+     }
+ 
+     SetRect(&rect, 0, 0, window_width, window_height);
+-    OffsetRect(&rect, data->rects.window.left, data->rects.window.top);
++    OffsetRect(&rect, saved_window_left, saved_window_top);
+     NtUserSetRawWindowPos(hwnd, rect, flags, FALSE);
+ }
+ 
+-- 
+2.53.0
+


### PR DESCRIPTION
CryEngine games (Hunt: Showdown being the main one, and the one that I tested) "fake minimize" during startup in exclusive fullscreen by moving the window to (-32000,-32000) and setting `WS_MINIMIZE`. On X11 this works fine because the driver detects `WS_MINIMIZE` and sets IconicState. On Wayland, the driver didn't handle this at all, so it sent `unset_fullscreen`, the compositor responded with a 0x0 configure, and Vulkan present stalled forever (frozen display, audio continues). This fix brings the Wayland driver in line with X11 by properly handling the minimize/restore cycle when a game requests it.

The fix:
- **Skip viewport update** for degenerate (0x0) client areas instead of setting 1x1, which was starving frame callbacks
- **Detect `WS_MINIMIZE`** and suppress `unset_fullscreen`/`unset_maximized` during minimize so the compositor doesn't send a harmful 0x0 configure
- **Handle restore** by acking the configure and sending `SC_RESTORE`, letting Win32 do the full restore sequence (matching X11 behavior)
- Also fixes an existing use-after-release on `data->rects` in `wayland_configure_window`

Tested on Fedora 44, Kernel 6.19.9, GNOME 50.0, Mesa 26.0.3, RX 9070 XT, GE-Proton 10-34. Hunt: Showdown launches, minimizes to dash, restores and renders normally in exclusive fullscreen. No perf regression vs XWayland (~62-64 FPS at Ultra). Also verified other games (Helldivers 2) are unaffected.