### PR TITLE
Remove surfaceless option from GST_BASE build args

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -298,7 +298,7 @@ GST_BASE_MESON_ARGS := \
 	-Dgl=enabled \
 	-Dgl-graphene=enabled \
 	-Drawparse=enabled \
-	-Dgl_winsys=surfaceless,x11,wayland,egl \
+	-Dgl_winsys=x11,wayland,egl \
 	-Dgl_platform=glx,egl \
 	--wrap-mode nodownload \
 


### PR DESCRIPTION
Fixes GE-Proton build on Fedora 43. "surfaceless" is not recognized as a valid option.

This also (somehow) fixes the latest Arknights Endfield Launcher installer (which was the initial issue that i was trying to debug).
Attempting to launch `GRYPHLINK_v1.2.2.1227_6_6_endfield.exe` obtained from the [official site](https://endfield.gryphline.com/) using the released GE 10-34 build is not possible. GE 10-33 works.
This has been tested on bare metal Bazzite, CachyOS and Linux Mint, using Faugus Launcher.

The launcher itself and the game work fine on the released GE 10-34 build. It's just the installer that's broken.

