### PR TITLE
patches: Only relocate files which have relocations

### DIFF
--- a/patches/proton/0001-server-Dynamically-relocate-.exes-by-default-too.patch
+++ b/patches/proton/0001-server-Dynamically-relocate-.exes-by-default-too.patch
@@ -1,4 +1,4 @@
-From 2c6f018382154afbba8f60b7fe075b1d2f817fda Mon Sep 17 00:00:00 2001
+From e1b4ddc1b28d46403500570219ac1b194e8cf23b Mon Sep 17 00:00:00 2001
 From: Jade Macho <ade@0x0a.de>
 Date: Wed, 18 Mar 2026 02:06:16 +0100
 Subject: [PATCH] server: Dynamically relocate .exes by default too
@@ -6,8 +6,8 @@ Subject: [PATCH] server: Dynamically relocate .exes by default too
 TODO: Should this only be enabled for Vista onwards? Toggleable?
 ---
  dlls/ntdll/unix/virtual.c | 1 -
- server/mapping.c          | 2 --
- 2 files changed, 3 deletions(-)
+ server/mapping.c          | 4 +---
+ 2 files changed, 1 insertion(+), 4 deletions(-)
 
 diff --git a/dlls/ntdll/unix/virtual.c b/dlls/ntdll/unix/virtual.c
 index 781598fced1..c46d2255475 100644
@@ -22,9 +22,18 @@ index 781598fced1..c46d2255475 100644
      {
          SERVER_START_REQ( get_image_map_address )
 diff --git a/server/mapping.c b/server/mapping.c
-index 69cd0a7451b..5e742342514 100644
+index 69cd0a7451b..47dc5de2893 100644
 --- a/server/mapping.c
 +++ b/server/mapping.c
+@@ -949,7 +949,7 @@ static unsigned int get_image_params( struct mapping *mapping, file_pos_t file_s
+     if (mapping->image.alignment & page_mask)
+         mapping->image.image_flags |= IMAGE_FLAGS_ImageMappedFlat;
+     else if ((mapping->image.dll_charact & IMAGE_DLLCHARACTERISTICS_DYNAMIC_BASE) &&
+-             (has_relocs || mapping->image.contains_code) && !(clr_va && clr_size))
++             has_relocs && !(clr_va && clr_size))
+         mapping->image.image_flags |= IMAGE_FLAGS_ImageDynamicallyRelocated;
+ 
+     align_mask = max( mapping->image.alignment - 1, page_mask );
 @@ -1286,8 +1286,6 @@ static client_ptr_t assign_map_address( struct mapping *mapping )
      struct addr_range *range = (mapping->image.base >> 32) ? &ranges64 : &ranges32;
      mem_size_t size = round_size( mapping->size, granularity_mask );


### PR DESCRIPTION
Current upstream wine behavior is to ignore `IMAGE_FILE_RELOCS_STRIPPED` if the file has a .text section and if `IMAGE_DLLCHARACTERISTICS_DYNAMIC_BASE` is set. This behavior makes no sense to me, and neither does this combo of flags, but it caught me off guard on _one_ .exe of dubious origin so far as reported by Zynki on Discord (thanks for helping me dig into this!). MSDN is strict and clear about the loader erroring if a `IMAGE_FILE_RELOCS_STRIPPED` file cannot be loaded at its preferred base address...

As to _why_ upstream wine does it like that: Judging by https://gitlab.winehq.org/wine/wine/-/commit/4847c1d8e4745ccd63e1db06fe1a693e8a591326, I can only assume that it's being done for historical reasons.

As an aside: This will need another update for 11.6, as this patch is incompatible after https://gitlab.winehq.org/wine/wine/-/commit/075adf4c1536491b405a1ddf8195149a02a6373