### PR TITLE
winex11+dxvk: real per-pixel alpha for layered 3D-overlay windows

### DIFF
--- a/patches/game-patches/layered-overlay-dxvk.patch
+++ b/patches/game-patches/layered-overlay-dxvk.patch
@@ -1,0 +1,37 @@
+Subject: [PATCH] dxvk: non-opaque compositeAlpha for layered overlay windows
+
+When WINE_LAYERED_OVERLAY_ALPHA is set, request a non-opaque Vulkan compositeAlpha
+(premultiplied/straight, falling back to INHERIT which is what X11 surfaces expose) so the
+compositor blends the swapchain's per-pixel alpha. Off by default. Pairs with the winex11
+ARGB-visual change. Enables real transparency (zero flicker) for DWM-glass overlay games.
+diff --git a/src/dxvk/dxvk_presenter.cpp b/src/dxvk/dxvk_presenter.cpp
+index f0d2651..51141c4 100644
+--- a/src/dxvk/dxvk_presenter.cpp
++++ b/src/dxvk/dxvk_presenter.cpp
+@@ -735,6 +735,26 @@ namespace dxvk {
+     swapInfo.imageSharingMode       = VK_SHARING_MODE_EXCLUSIVE;
+     swapInfo.preTransform           = VK_SURFACE_TRANSFORM_IDENTITY_BIT_KHR;
+     swapInfo.compositeAlpha         = VK_COMPOSITE_ALPHA_OPAQUE_BIT_KHR;
++
++    // Layered overlay (WINE_LAYERED_OVERLAY_ALPHA): request per-pixel alpha compositing
++    // so transparent regions show the desktop instead of an opaque black box. The value
++    // selects the blend mode for testing without a rebuild: 1 = premultiplied, 2 = straight.
++    if (std::string overlayAlpha = env::getEnvVar("WINE_LAYERED_OVERLAY_ALPHA"); !overlayAlpha.empty()) {
++      VkCompositeAlphaFlagsKHR supported = caps.surfaceCapabilities.supportedCompositeAlpha;
++      VkCompositeAlphaFlagBitsKHR want = (overlayAlpha == "2")
++        ? VK_COMPOSITE_ALPHA_POST_MULTIPLIED_BIT_KHR : VK_COMPOSITE_ALPHA_PRE_MULTIPLIED_BIT_KHR;
++      VkCompositeAlphaFlagBitsKHR alt = (overlayAlpha == "2")
++        ? VK_COMPOSITE_ALPHA_PRE_MULTIPLIED_BIT_KHR : VK_COMPOSITE_ALPHA_POST_MULTIPLIED_BIT_KHR;
++      // On X11 the driver typically exposes only INHERIT (the per-pixel alpha comes from
++      // the window's ARGB visual); PRE/POST are mainly a Wayland thing. Try the requested
++      // mode, then the other, then INHERIT, before giving up to OPAQUE.
++      if (supported & want) swapInfo.compositeAlpha = want;
++      else if (supported & alt) swapInfo.compositeAlpha = alt;
++      else if (supported & VK_COMPOSITE_ALPHA_INHERIT_BIT_KHR) swapInfo.compositeAlpha = VK_COMPOSITE_ALPHA_INHERIT_BIT_KHR;
++      Logger::info(str::format("Layered overlay: compositeAlpha -> ", uint32_t(swapInfo.compositeAlpha),
++        " (surface supports ", uint32_t(supported), ")"));
++    }
++
+     swapInfo.presentMode            = m_presentMode;
+     swapInfo.clipped                = VK_TRUE;
+ 

--- a/patches/game-patches/layered-overlay-wine.patch
+++ b/patches/game-patches/layered-overlay-wine.patch
@@ -1,0 +1,401 @@
+Subject: [PATCH] winex11: shaped + real-alpha transparency for layered 3D-overlay windows
+
+Borderless WS_EX_LAYERED windows that paint per-pixel-alpha overlays through a 3D client
+surface (DWM-glass style; e.g. desktop/taskbar overlay games) render transparent regions
+as opaque black under Proton, because Wine does not honour the DWM glass path.
+
+Two opt-in modes (off by default, no effect on other games):
+ * WINE_LAYERED_OVERLAY_SHAPE=1 - XShape the window to rendered non-black pixels (works
+   without a compositor; binary mask + temporal hysteresis to avoid flicker).
+ * WINE_LAYERED_OVERLAY_ALPHA=1 - real per-pixel alpha: give the Vulkan client window AND
+   the top-level window a 32-bit ARGB visual + use_alpha so the X compositor blends the
+   alpha (zero flicker). Pairs with the DXVK presenter requesting a non-opaque
+   compositeAlpha. Requires a compositing window manager.
+
+Based on the original TBH-specific XShape patch by Solarisfire; generalised, flicker fixed,
+and extended with the real-alpha (ARGB) path.
+diff --git a/dlls/winex11.drv/x11drv.h b/dlls/winex11.drv/x11drv.h
+index 9436f35e1c..5975c860b6 100644
+--- a/dlls/winex11.drv/x11drv.h
++++ b/dlls/winex11.drv/x11drv.h
+@@ -367,6 +367,8 @@ struct x11drv_escape_get_drawable
+ };
+ 
+ extern BOOL needs_offscreen_rendering( HWND hwnd );
++extern BOOL layered_overlay_shape_enabled(void);
++extern BOOL layered_overlay_alpha_enabled(void);
+ extern void set_dc_drawable( HDC hdc, Drawable drawable, const RECT *rect, int mode );
+ extern Drawable get_dc_drawable( HDC hdc, RECT *rect );
+ extern HRGN get_dc_monitor_region( HWND hwnd, HDC hdc );
+diff --git a/dlls/winex11.drv/init.c b/dlls/winex11.drv/init.c
+index 479ff421a3..19ea1ef5fa 100644
+--- a/dlls/winex11.drv/init.c
++++ b/dlls/winex11.drv/init.c
+@@ -33,6 +33,9 @@
+ #include "x11drv.h"
+ #include "xcomposite.h"
+ #include "wine/debug.h"
++#ifdef HAVE_LIBXSHAPE
++#include <X11/extensions/shape.h>
++#endif
+ 
+ WINE_DEFAULT_DEBUG_CHANNEL(x11drv);
+ 
+@@ -242,9 +245,40 @@ static BOOL enable_fullscreen_hack( HWND hwnd )
+     return FALSE;
+ }
+ 
++/* Opt-in via WINE_LAYERED_OVERLAY_SHAPE=1. For borderless WS_EX_LAYERED windows that
++ * paint per-pixel-alpha overlays through a 3D client surface (DWM-glass style, e.g.
++ * desktop/taskbar overlay games), shape the X window to the rendered (non-black) pixels
++ * so transparent areas show the desktop instead of an opaque black box, and let the
++ * window receive mouse input. Disabled by default: no effect on any other game. */
++BOOL layered_overlay_shape_enabled(void)
++{
++    static int enabled = -1;
++    if (enabled == -1)
++    {
++        const char *e = getenv( "WINE_LAYERED_OVERLAY_SHAPE" );
++        enabled = e && atoi( e );
++    }
++    return enabled;
++}
++
++/* Opt-in via WINE_LAYERED_OVERLAY_ALPHA=1|2. Real per-pixel-alpha path: give the
++ * Vulkan overlay window a 32-bit ARGB visual so the X compositor blends transparency
++ * directly (no XShape). Pairs with vkd3d-proton requesting a non-opaque compositeAlpha. */
++BOOL layered_overlay_alpha_enabled(void)
++{
++    static int enabled = -1;
++    if (enabled == -1)
++    {
++        const char *e = getenv( "WINE_LAYERED_OVERLAY_ALPHA" );
++        enabled = e && atoi( e );
++    }
++    return enabled;
++}
++
+ BOOL needs_offscreen_rendering( HWND hwnd )
+ {
+     UINT style = NtUserGetWindowLongW( hwnd, GWL_STYLE );
++    UINT ex_style = NtUserGetWindowLongW( hwnd, GWL_EXSTYLE );
+     struct window_surface *surface;
+     struct x11drv_win_data *data;
+     BOOL needs_offscreen;
+@@ -261,6 +295,10 @@ BOOL needs_offscreen_rendering( HWND hwnd )
+         && layered_flags & LWA_COLORKEY)
+         needs_offscreen = TRUE;
+ 
++    /* Layered overlay (DWM-glass style) painting per-pixel alpha via a 3D client surface. */
++    if (!needs_offscreen && layered_overlay_shape_enabled() && (ex_style & WS_EX_LAYERED))
++        needs_offscreen = TRUE;
++
+     if (!needs_offscreen && (surface = window_surface_get( hwnd )))
+     {
+         TRACE("hwnd %p, surface %p, surface->alpha_mask %#x.\n", hwnd, surface, surface->alpha_mask);
+@@ -320,6 +358,13 @@ struct x11drv_client_surface
+     HDC hdc_src;
+     HDC hdc_dst;
+     BOOL other_process;
++
++    BYTE *shape_age;
++    unsigned int shape_cols;
++    unsigned int shape_rows;
++
++    XRectangle *shape_rects;
++    unsigned int shape_rect_count;
+ };
+ 
+ static struct x11drv_client_surface *impl_from_client_surface( struct client_surface *client )
+@@ -338,6 +383,8 @@ static void x11drv_client_surface_destroy( struct client_surface *client )
+     if (surface->window) destroy_client_window( hwnd, surface->window );
+     if (surface->hdc_dst) NtGdiDeleteObjectApp( surface->hdc_dst );
+     if (surface->hdc_src) NtGdiDeleteObjectApp( surface->hdc_src );
++    free( surface->shape_age );
++    free( surface->shape_rects );
+ }
+ 
+ static void x11drv_client_surface_detach( struct client_surface *client )
+@@ -464,6 +511,127 @@ static void x11drv_client_surface_update( struct client_surface *client )
+     client_surface_update_offscreen( hwnd, surface );
+ }
+ 
++/* Returns TRUE if the client window has actually-visible pixels this frame (ignoring age
++   hysteresis). A FALSE return means the D3D pipeline delivered a cleared/black frame —
++   the caller should skip blitting to avoid overwriting screen pixels with the clear colour. */
++static BOOL update_layered_overlay_shape( struct x11drv_client_surface *surface, HWND toplevel )
++{
++#ifdef HAVE_LIBXSHAPE
++    unsigned int width, height, cols, rows, x, y, count = 0, capacity;
++    BOOL actually_visible = FALSE;
++    XRectangle *rects;
++    XImage *image;
++    Window window;
++
++    if (!layered_overlay_shape_enabled()) return TRUE;
++
++    width = surface->rect.right - surface->rect.left;
++    height = surface->rect.bottom - surface->rect.top;
++    if (!width || !height || !(window = X11DRV_get_whole_window( toplevel ))) return TRUE;
++
++    cols = (width + 3) / 4;
++    rows = (height + 3) / 4;
++    if (cols != surface->shape_cols || rows != surface->shape_rows)
++    {
++        free( surface->shape_age );
++        surface->shape_age = calloc( cols * rows, sizeof(*surface->shape_age) );
++        surface->shape_cols = cols;
++        surface->shape_rows = rows;
++        free( surface->shape_rects );
++        surface->shape_rects = NULL;
++        surface->shape_rect_count = 0;
++    }
++    if (!surface->shape_age) return TRUE;
++
++    if (!(image = XGetImage( gdi_display, surface->window, 0, 0, width, height, AllPlanes, ZPixmap ))) return TRUE;
++
++    capacity = cols * rows;
++    if (!(rects = malloc( capacity * sizeof(*rects) )))
++    {
++        XDestroyImage( image );
++        return TRUE;
++    }
++
++    for (y = 0; y < height; y += 4)
++    {
++        int run_start = -1;
++
++        for (x = 0; x < width; x += 4)
++        {
++            BYTE *age = &surface->shape_age[(y / 4) * cols + x / 4];
++            unsigned int xx, yy;
++            BOOL visible = FALSE;
++
++            for (yy = y; yy < min( y + 4, height ) && !visible; yy++)
++                for (xx = x; xx < min( x + 4, width ); xx++)
++                    if (XGetPixel( image, xx, yy ) & 0x00f0f0f0)
++                    {
++                        visible = TRUE;
++                        break;
++                    }
++
++            /* Hysteresis: a block stays in the shape for several frames after it was
++               last seen lit. This absorbs the transient all/partial-black frames that
++               XGetImage catches while the window is being moved or re-rendered on
++               mouse hover (the live X window is read mid-update) -- which would
++               otherwise shrink the shape every active frame and flicker. Growth is
++               instant (content shows immediately); only shrink is delayed, a brief
++               and barely-visible trail. */
++            if (visible) { *age = 12; actually_visible = TRUE; }
++            else if (*age) --*age;
++
++            if (*age && run_start < 0) run_start = x;
++            if ((!*age || x + 4 >= width) && run_start >= 0)
++            {
++                unsigned int end = *age ? width : x;
++
++                rects[count].x = surface->changes.x + run_start;
++                rects[count].y = surface->changes.y + y;
++                rects[count].width = end - run_start;
++                rects[count].height = min( 4, height - y );
++                count++;
++                run_start = -1;
++            }
++        }
++    }
++
++    XDestroyImage( image );
++
++    /* Only call XShapeCombineRectangles when the shape actually changed.
++       Always update on the first call (!shape_rects) — a new or resized window
++       has the default X11 shape (full rectangle visible), so if the first frame
++       is all-black (D3D clear colour, count==0) we must explicitly clip it to
++       nothing, otherwise the black pixels show as an opaque black rectangle. */
++    if (!surface->shape_rects ||
++        count != surface->shape_rect_count ||
++        (count > 0 && memcmp( rects, surface->shape_rects, count * sizeof(*rects) )))
++    {
++        if (count)
++            XShapeCombineRectangles( gdi_display, window, ShapeBounding, 0, 0, rects, count, ShapeSet, YXBanded );
++        else
++        {
++            static XRectangle empty;
++            XShapeCombineRectangles( gdi_display, window, ShapeBounding, 0, 0, &empty, 1, ShapeSet, YXBanded );
++        }
++
++        TRACE( "layered overlay window %p/%lx shape updated with %u rectangles\n", toplevel, window, count );
++        XFlush( gdi_display );
++
++        free( surface->shape_rects );
++        surface->shape_rects = rects;
++        surface->shape_rect_count = count;
++    }
++    else
++    {
++        free( rects );
++    }
++
++    return actually_visible;
++#else
++    return TRUE;
++#endif
++}
++
+ static void X11DRV_client_surface_present( struct client_surface *client, HDC hdc )
+ {
+     struct x11drv_client_surface *surface = impl_from_client_surface( client );
+@@ -494,8 +662,12 @@ static void X11DRV_client_surface_present( struct client_surface *client, HDC hd
+         TRACE( "Surface is present.\n" );
+         region = get_dc_monitor_region( hwnd, hdc );
+         if (region) NtGdiExtSelectClipRgn( hdc, region, RGN_COPY );
+-        NtGdiStretchBlt( hdc, 0, 0, surface->rect.right - surface->rect.left, surface->rect.bottom - surface->rect.top,
+-                         surface->hdc_src, 0, 0, surface->rect.right, surface->rect.bottom, SRCCOPY, 0 );
++        /* Layered overlay: shape check runs first. If it returns FALSE the client
++           window holds the D3D clear colour — skip the blit so the previous correct
++           pixels stay in the whole window, avoiding flicker. */
++        if (update_layered_overlay_shape( surface, toplevel ))
++            NtGdiStretchBlt( hdc, 0, 0, surface->rect.right - surface->rect.left, surface->rect.bottom - surface->rect.top,
++                             surface->hdc_src, 0, 0, surface->rect.right, surface->rect.bottom, SRCCOPY, 0 );
+         if (region) NtGdiDeleteObjectApp( region );
+         window_surface_release( win_surface );
+         return;
+@@ -528,8 +700,9 @@ static void X11DRV_client_surface_present( struct client_surface *client, HDC hd
+         set_dc_drawable( surface->hdc_dst, window, &rect_dst, IncludeInferiors );
+     if (region) NtGdiExtSelectClipRgn( surface->hdc_dst, region, RGN_COPY );
+ 
+-    NtGdiStretchBlt( surface->hdc_dst, 0, 0, rect_dst.right - rect_dst.left, rect_dst.bottom - rect_dst.top,
+-                     surface->hdc_src, 0, 0, surface->rect.right, surface->rect.bottom, SRCCOPY, 0 );
++    if (update_layered_overlay_shape( surface, toplevel ))
++        NtGdiStretchBlt( surface->hdc_dst, 0, 0, rect_dst.right - rect_dst.left, rect_dst.bottom - rect_dst.top,
++                         surface->hdc_src, 0, 0, surface->rect.right, surface->rect.bottom, SRCCOPY, 0 );
+     XFlush( gdi_display );
+ 
+ done:
+@@ -571,6 +744,22 @@ Window x11drv_client_surface_create( HWND hwnd, BOOL raw, int format, struct cli
+ 
+     if (format && !visual_from_pixel_format( format, &visual )) return None;
+ 
++    /* Layered overlay (WINE_LAYERED_OVERLAY_ALPHA): use a 32-bit ARGB visual for the
++     * Vulkan surface window so the X compositor can blend its per-pixel alpha. The env
++     * var already scopes this to the opted-in game, so apply unconditionally — the
++     * window may not be WS_EX_LAYERED yet when the Vulkan surface is first created. */
++    if (!format && layered_overlay_alpha_enabled())
++    {
++        if (argb_visual.visualid)
++        {
++            visual = argb_visual;
++            TRACE( "layered overlay: using ARGB visual %#lx depth %d for hwnd %p\n",
++                   visual.visualid, visual.depth, hwnd );
++        }
++        else
++            WARN( "layered overlay: no 32-bit ARGB visual available, transparency unavailable\n" );
++    }
++
+     if (visual.visualid == default_visual.visualid) colormap = default_colormap;
+     else colormap = XCreateColormap( gdi_display, get_dummy_parent(), visual.visual, visual_class_alloc( visual.class ) );
+     if (!colormap) return None;
+diff --git a/dlls/winex11.drv/window.c b/dlls/winex11.drv/window.c
+index 63a8536c71..fa0aafe4d4 100644
+--- a/dlls/winex11.drv/window.c
++++ b/dlls/winex11.drv/window.c
+@@ -431,7 +431,6 @@ static struct x11drv_win_data *alloc_win_data( Display *display, HWND hwnd )
+     return data;
+ }
+ 
+-
+ static BOOL thickframe_managed( DWORD style )
+ {
+     static int cached = -1;
+@@ -537,7 +536,7 @@ static unsigned long get_mwm_decorations_for_style( DWORD style, DWORD ex_style
+     if (X11DRV_HasWindowManager( "Mutter" )) return 0;
+ 
+     if (ex_style & WS_EX_TOOLWINDOW) return 0;
+-    if (ex_style & WS_EX_LAYERED) return 0;
++    if ((ex_style & (WS_EX_LAYERED | WS_EX_COMPOSITED)) == WS_EX_LAYERED) return 0;
+ 
+     if ((style & WS_CAPTION) == WS_CAPTION)
+     {
+@@ -568,6 +567,7 @@ static unsigned long get_mwm_decorations( struct x11drv_win_data *data, DWORD st
+ static int get_window_attributes( struct x11drv_win_data *data, XSetWindowAttributes *attr )
+ {
+     DWORD ex_style = NtUserGetWindowLongW( data->hwnd, GWL_EXSTYLE );
++    BOOL overlay = layered_overlay_shape_enabled() || layered_overlay_alpha_enabled();
+ 
+     attr->colormap          = data->whole_colormap ? data->whole_colormap : default_colormap;
+     attr->save_under        = ((NtUserGetClassLongW( data->hwnd, GCL_STYLE ) & CS_SAVEBITS) != 0);
+@@ -577,9 +577,10 @@ static int get_window_attributes( struct x11drv_win_data *data, XSetWindowAttrib
+     attr->background_pixel  = 0;
+     attr->event_mask        = (ExposureMask | KeyPressMask | KeyReleaseMask |
+                                FocusChangeMask | KeymapStateMask | StructureNotifyMask | PropertyChangeMask);
+-    /* for transparent windows, exclude mouse events to allow mouse pass-through */
+-    if (!(ex_style & WS_EX_TRANSPARENT)) attr->event_mask |= (PointerMotionMask | ButtonPressMask |
+-                                                              ButtonReleaseMask | EnterWindowMask);
++    /* for transparent windows, exclude mouse events to allow mouse pass-through
++       (overlay-shape mode keeps input so the shaped overlay stays interactive) */
++    if (!(ex_style & WS_EX_TRANSPARENT) || overlay) attr->event_mask |= (PointerMotionMask | ButtonPressMask |
++                                                                       ButtonReleaseMask | EnterWindowMask);
+ 
+     return (CWSaveUnder | CWColormap | CWBorderPixel | CWBackPixel |
+             CWEventMask | CWBitGravity | CWBackingStore);
+@@ -596,10 +597,11 @@ static void sync_window_input_shape( struct x11drv_win_data *data )
+ {
+ #ifdef HAVE_LIBXSHAPE
+     DWORD ex_style = NtUserGetWindowLongW( data->hwnd, GWL_EXSTYLE );
++    BOOL overlay = layered_overlay_shape_enabled() || layered_overlay_alpha_enabled();
+ 
+     if (!data->whole_window) return;
+ 
+-    if (ex_style & WS_EX_TRANSPARENT)
++    if ((ex_style & WS_EX_TRANSPARENT) && !overlay)
+     {
+         /* For transparent windows, set an empty input shape to allow mouse pass-through */
+         static XRectangle empty_rect;
+@@ -2763,6 +2765,17 @@ static void create_whole_window( struct x11drv_win_data *data )
+     }
+     data->shaped = (win_rgn != 0);
+ 
++    /* Layered overlay (WINE_LAYERED_OVERLAY_ALPHA): give the TOP-LEVEL window a 32-bit
++     * ARGB visual with per-pixel alpha so the compositor blends it (real transparency).
++     * The Vulkan child window being ARGB is not enough — the compositor composites the
++     * top-level, which must itself carry alpha. Env-var scoped to the opted-in game. */
++    if (layered_overlay_alpha_enabled() && argb_visual.visualid &&
++        data->vis.visualid != argb_visual.visualid)
++    {
++        data->vis = argb_visual;
++        data->use_alpha = TRUE;
++    }
++
+     if (data->vis.visualid != default_visual.visualid)
+         data->whole_colormap = XCreateColormap( data->display, root_window, data->vis.visual, AllocNone );
+ 
+@@ -2946,7 +2959,12 @@ void X11DRV_SetWindowStyle( HWND hwnd, INT offset, STYLESTRUCT *style )
+         if (changed & WS_EX_LAYERED) /* changing WS_EX_LAYERED resets attributes */
+         {
+             data->layered = FALSE;
+-            set_window_visual( data, &default_visual, FALSE );
++            /* Layered overlay (WINE_LAYERED_OVERLAY_ALPHA): keep the ARGB visual instead
++             * of resetting to the opaque default, so the compositor keeps blending. */
++            if (layered_overlay_alpha_enabled() && argb_visual.visualid)
++                set_window_visual( data, &argb_visual, TRUE );
++            else
++                set_window_visual( data, &default_visual, FALSE );
+             sync_window_opacity( data->display, data->whole_window, 0, 0 );
+         }
+         if (changed & WS_EX_TRANSPARENT) sync_window_style( data );
+@@ -3663,7 +3681,7 @@ void X11DRV_WindowPosChanged( HWND hwnd, HWND insert_after, HWND owner_hint, UIN
+ 
+     /* layered windows are mapped only once their attributes are set */
+     if (data->pending_state.wm_state == WithdrawnState && (new_style & WS_VISIBLE) &&
+-        (ex_style & WS_EX_LAYERED) && !data->layered && !IsRectEmpty( &new_rects->window ))
++        (ex_style & (WS_EX_LAYERED | WS_EX_COMPOSITED)) == WS_EX_LAYERED && !data->layered && !IsRectEmpty( &new_rects->window ))
+     {
+         WARN( "win %p/%lx is layered, delaying mapping\n", hwnd, data->whole_window );
+         new_style &= ~WS_VISIBLE;
+@@ -4162,6 +4180,7 @@ void net_supporting_wm_check_init( struct x11drv_thread_data *data )
+         char const *sgi = getenv( "SteamGameId" );
+ 
+         if (!strcmp( data->window_manager, "GNOME Shell" )) strcpy( data->window_manager, "Mutter" );
++        if (!strcmp( data->window_manager, "Mutter (Muffin)" )) strcpy( data->window_manager, "Mutter" );
+         TRACE( "Detected window manager: %s\n", debugstr_a(data->window_manager) );
+ 
+         /* Street Fighter V expects a certain sequence of window resizes

--- a/patches/protonprep-valve-staging.sh
+++ b/patches/protonprep-valve-staging.sh
@@ -18,6 +18,7 @@ apply_all_in_dir() {
     pushd dxvk
     git reset --hard HEAD
     git clean -xdf
+    patch -Np1 < ../patches/game-patches/layered-overlay-dxvk.patch
     popd
 
     pushd vkd3d-proton
@@ -210,6 +211,7 @@ apply_all_in_dir() {
     echo "WINE: -GAME FIXES- add fixes for star citizen"
     apply_patch "../patches/game-patches/silence-starcitizen-unsupported-os.patch"
     apply_patch "../patches/game-patches/eac_60101_timeout.patch"
+    apply_patch "../patches/game-patches/layered-overlay-wine.patch"
 
 
 ### END GAME PATCH SECTION ###


### PR DESCRIPTION
## Summary

Real **per-pixel alpha** transparency for borderless `WS_EX_LAYERED` 3D-overlay windows
(DWM-glass style; e.g. **TBH: Task Bar Hero**, AppID 3678970) — **zero flicker**, true
semi-transparency. Opt-in via `WINE_LAYERED_OVERLAY_ALPHA=1` (no effect on other games).

This is the "correct" counterpart to the XShape approach in #553: instead of clipping the
window shape (binary mask, can flicker), it makes the compositor blend the real alpha.

## Changes
- **winex11** (`layered-overlay-wine.patch`): 32-bit ARGB visual + `use_alpha` on the Vulkan
  client window **and the top-level window** (the compositor composites the top-level — that
  was the key); keep ARGB across `WS_EX_LAYERED` toggles. Also includes the XShape mode.
- **DXVK** (`layered-overlay-dxvk.patch`): non-opaque `compositeAlpha` in the presenter
  (`INHERIT` on X11, `PRE_MULTIPLIED` with an ARGB window).

The DXVK present shader already preserves source alpha, so the game's real alpha then reaches
the compositor untouched.

## Notes
- Needs a compositing WM (KWin/Mutter/picom). #553 (XShape) remains the no-compositor fallback.
- Tested on KDE Plasma Wayland: transparent, interactive, zero flicker.
- Write-up: ValveSoftware/Proton#9841. Core approach + investigation: @Solarisfire.
