### PR TITLE
proton: do not terminate process if xrandr fails

### DIFF
--- a/proton
+++ b/proton
@@ -1801,10 +1801,10 @@ class Session:
             )
         except FileNotFoundError:
             print("Error: xrandr is not installed or not in PATH.", file=sys.stderr)
-            sys.exit(1)
+            return None
         except subprocess.CalledProcessError as e:
             print(f"Error: failed to run xrandr: {e}", file=sys.stderr)
-            sys.exit(1)
+            return None
 
         for line in result.stdout.splitlines():
             # Example:


### PR DESCRIPTION
Proton-GE terminates if `xrandr` returns an error when trying to get the primary monitor.

This seems unnecessary, as failing to detect the primary monitor does not prevent games from running normally and proton-ge already handles the case where no primary monitor is detected.


```
Game Recording - would start recording game 2225070, but recording for this game is disabled
Adding process 33985 for gameID 2225070
Adding process 33990 for gameID 2225070
Adding process 33992 for gameID 2225070
Adding process 34106 for gameID 2225070
ProtonFixes[34106] INFO: Running protonfixes on "GE-Proton10-34", build at 2026-03-23 03:55:11+00:00.
ProtonFixes[34106] INFO: Running checks
ProtonFixes[34106] INFO: All checks successful
ProtonFixes[34106] INFO: Using early stage global defaults for "Trackmania" (2225070)
ProtonFixes[34106] INFO: No early stage global protonfix found for "Trackmania" (2225070)
Error: failed to run xrandr: Command '['xrandr']' returned non-zero exit status 1.
Adding process 34107 for gameID 2225070
Game Recording - game stopped [gameid=2225070]
Removing process 34107 for gameID 2225070
Removing process 34106 for gameID 2225070
Removing process 33992 for gameID 2225070
Removing process 33990 for gameID 2225070
Removing process 33985 for gameID 2225070
```