### PR TITLE
Fix download scripts for the new aarch64 builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ cd /tmp/proton-ge-custom
 echo "Fetching tarball URL..."
 case "$(uname -m)" in
     aarch64|arm64) tarball_pattern='-aarch64\.tar\.gz$' ;;
-    *)             tarball_pattern='GE-Proton[^/]*[0-9]\.tar\.gz$' ;;
+    *)             tarball_pattern='GE-Proton[0-9-]*[0-9]\.tar\.gz$' ;;
 esac
 tarball_url=$(curl -s https://api.github.com/repos/GloriousEggroll/proton-ge-custom/releases/latest | grep browser_download_url | cut -d\" -f4 | grep -E "$tarball_pattern" | head -n1)
 tarball_name=$(basename $tarball_url)
@@ -144,7 +144,7 @@ curl -# -L $tarball_url -o $tarball_name --no-progress-meter
 
 # Download the checksum for the latest release
 echo "Fetching checksum URL..."
-checksum_url=$(curl -s https://api.github.com/repos/GloriousEggroll/proton-ge-custom/releases/latest | grep browser_download_url | cut -d\" -f4 | grep "${tarball_name}.sha512sum")
+checksum_url=$(curl -s https://api.github.com/repos/GloriousEggroll/proton-ge-custom/releases/latest | grep browser_download_url | cut -d\" -f4 | grep "${tarball_name%.tar.gz}.sha512sum")
 checksum_name=$(basename $checksum_url)
 echo "Downloading checksum: $checksum_name..."
 curl -# -L $checksum_url -o $checksum_name --no-progress-meter
@@ -211,7 +211,7 @@ cd /tmp/proton-ge-custom
 echo "Fetching tarball URL..."
 case "$(uname -m)" in
     aarch64|arm64) tarball_pattern='-aarch64\.tar\.gz$' ;;
-    *)             tarball_pattern='GE-Proton[^/]*[0-9]\.tar\.gz$' ;;
+    *)             tarball_pattern='GE-Proton[0-9-]*[0-9]\.tar\.gz$' ;;
 esac
 tarball_url=$(curl -s https://api.github.com/repos/GloriousEggroll/proton-ge-custom/releases/latest | grep browser_download_url | cut -d\" -f4 | grep -E "$tarball_pattern" | head -n1)
 tarball_name=$(basename $tarball_url)
@@ -220,7 +220,7 @@ curl -# -L $tarball_url -o $tarball_name --no-progress-meter
 
 # Download the checksum for the latest release 
 echo "Fetching checksum URL..."
-checksum_url=$(curl -s https://api.github.com/repos/GloriousEggroll/proton-ge-custom/releases/latest | grep browser_download_url | cut -d\" -f4 | grep "${tarball_name}.sha512sum")
+checksum_url=$(curl -s https://api.github.com/repos/GloriousEggroll/proton-ge-custom/releases/latest | grep browser_download_url | cut -d\" -f4 | grep "${tarball_name%.tar.gz}.sha512sum")
 checksum_name=$(basename $checksum_url)
 echo "Downloading checksum: $checksum_name..."
 curl -# -L $checksum_url -o $checksum_name --no-progress-meter


### PR DESCRIPTION
Since the aarch64 builds were added, the README download scripts started grabbing the wrong files:
- On x86_64 the script was downloading the aarch64 archive. The pattern that was supposed to match the normal build also matched GE-Proton11-1-aarch64.tar.gz, and since that one is listed first it got picked.
- Also, the checksum step was looking for a file like GE-Proton11-1.tar.gz.sha512sum, but the real file is named GE-Proton11-1.sha512sum, so verification failed.

I fixed both so x86_64 and aarch64 each get the right archive and checksum. Tested against the latest release. Applied to the Steam and Flatpak blocks in README.