### PR TITLE
Correct aarch64 regex in download script

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ fi
 echo "Fetching release for your arch..."
 
 case "$(uname -m)" in
-    aarch64|arm64) tarball_pattern='-aarch64\.tar\.gz$' ;;
+    aarch64|arm64) tarball_pattern='\-aarch64\.tar\.gz$' ;;
     x86_64)        tarball_pattern='GE-Proton[0-9]+-[0-9]+\.tar\.gz$' ;;
     *)
         echo "Error: Unsupported architecture: $(uname -m)." >&2


### PR DESCRIPTION
The `-` from `-aarch64` seems to freak out bash.

Log from current HEAD:
```
Making sure temporary directory exists...
Fetching release info...
Fetching release for your arch...
grep: invalid option -- '\'
Usage: grep [OPTION]... PATTERNS [FILE]...
Try 'grep --help' for more information.
Error: Could not find a matching release for your arch (aarch64).
```

Escaping that `-` fixes it. 