### PR TITLE
patches: add MapleStory SPI_SETSTICKYKEYS/SETFILTERKEYS game fix

### DIFF
--- a/patches/game-patches/maplestory-spi-stickykeys-filterkeys.patch
+++ b/patches/game-patches/maplestory-spi-stickykeys-filterkeys.patch
@@ -1,0 +1,38 @@
+From cd688b68811422f37f2a68d0348d851dfa51fca5 Mon Sep 17 00:00:00 2001
+From: oldschoola <f0rm4tm3@gmail.com>
+Date: Sat, 27 Jun 2026 22:17:19 -0700
+Subject: [PATCH] win32u: Accept SPI_SETSTICKYKEYS/SPI_SETFILTERKEYS as ignored
+ successes.
+
+MapleStory (Steam app 216150) calls SystemParametersInfo with SPI_SETSTICKYKEYS and SPI_SETFILTERKEYS at launch to disable those accessibility features. Both SET actions are only stubbed through WINE_SPI_FIXME, which logs and returns failure; the failed calls contribute to the game failing to start under Proton.
+
+Use WINE_SPI_WARN instead, which logs and returns success, matching how other unimplemented SET actions such as SPI_SETANIMATION are already handled. The settings are not actually applied (Wine has no host accessibility integration on this path), only accepted.
+---
+ dlls/win32u/sysparams.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/dlls/win32u/sysparams.c b/dlls/win32u/sysparams.c
+index 239d13d..c638b78 100644
+--- a/dlls/win32u/sysparams.c
++++ b/dlls/win32u/sysparams.c
+@@ -6393,7 +6393,7 @@ BOOL WINAPI NtUserSystemParametersInfo( UINT action, UINT val, void *ptr, UINT w
+         }
+         break;
+     }
+-    WINE_SPI_FIXME(SPI_SETFILTERKEYS);
++    WINE_SPI_WARN(SPI_SETFILTERKEYS);
+ 
+     case SPI_GETTOGGLEKEYS:
+     {
+@@ -6449,7 +6449,7 @@ BOOL WINAPI NtUserSystemParametersInfo( UINT action, UINT val, void *ptr, UINT w
+         break;
+     }
+ 
+-    WINE_SPI_FIXME(SPI_SETSTICKYKEYS);
++    WINE_SPI_WARN(SPI_SETSTICKYKEYS);
+ 
+     case SPI_GETACCESSTIMEOUT:
+     {
+-- 
+2.54.0
+

--- a/patches/protonprep-valve-staging.sh
+++ b/patches/protonprep-valve-staging.sh
@@ -220,6 +220,9 @@ apply_all_in_dir() {
     echo "WINE: -GAME FIXES- add fixes Guilty Gear Accent Core Plus R intro video (win32u related)"
     apply_patch "../patches/game-patches/0001-win32u-Avoid-zero-WM_ACTIVATEAPP-lparam-on-first-for.patch"
 
+    echo "WINE: -GAME FIXES- make MapleStory launch: accept SPI_SETSTICKYKEYS/SPI_SETFILTERKEYS"
+    apply_patch "../patches/game-patches/maplestory-spi-stickykeys-filterkeys.patch"
+
 ### END GAME PATCH SECTION ###
 
 ### (2-5) WINE HOTFIX/BACKPORT SECTION ###


### PR DESCRIPTION
Fixes #600.

Switch the `SPI_SETSTICKYKEYS` and `SPI_SETFILTERKEYS` stubs in `dlls/win32u/sysparams.c` from `WINE_SPI_FIXME` (logs + returns **failure**) to `WINE_SPI_WARN` (logs + returns **success**), so MapleStory (Steam app `216150`) stops failing its launch-time accessibility calls and can start under GE-Proton.

This mirrors how Wine already handles other unimplemented SET actions such as `SPI_SETANIMATION` and `SPI_LANGDRIVER`. The settings are not actually applied (Wine has no host accessibility integration on this path), only accepted — which is sufficient for the game to proceed.

The patch is verified to apply cleanly to the pinned wine submodule (`31af7f983b`). The game-patch is wired into `patches/protonprep-valve-staging.sh` alongside the other game fixes.

See #600 for full context, the other (separately-tracked) MapleStory launch gaps, and reproduction steps.
