### PR TITLE
docs: expand compatibility report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/compatibility-report.md
+++ b/.github/ISSUE_TEMPLATE/compatibility-report.md
@@ -16,23 +16,44 @@ THE GE-PROTON ISSUE TRACKER IS FOR ISSUES THAT ONLY OCCUR ON GE-PROTON BUT WORK 
 - Steam AppID of the game:
 
 ## System Information
-- GPU: <!-- e.g. RX 580 or GTX 970 -->
-- Driver/LLVM version: <!-- e.g. Mesa 18.2/7.0.0 or nvidia 396.54 -->
-- Kernel version: <!-- e.g. 4.17 -->
+- GPU: <!-- e.g. RX 580, RX 7900 XT, RTX 4070 -->
+- Driver/LLVM version: <!-- e.g. Mesa 25.2.6 / LLVM 21.0.0 or NVIDIA 575.64 -->
+- Kernel version: <!-- e.g. 6.15.6 -->
+- Distro version: <!-- e.g. Fedora 42, Bazzite, Arch, Nobara, Ubuntu 26.04 -->
+- Desktop session: <!-- e.g. KDE Wayland, GNOME Wayland, X11 -->
 - Link to full system information report as [Gist](https://gist.github.com/):
 - Proton version:
+
+## Proton comparison
+<!-- Please test with a clean prefix where possible. If a game has DRM/anti-tamper limits, mention that. -->
+- Works with Proton Experimental: <!-- yes/no/not tested -->
+- Works with Proton Experimental bleeding-edge: <!-- yes/no/not tested -->
+- Works with latest Valve Proton stable: <!-- yes/no/not tested/version -->
+- Works with previous GE-Proton version: <!-- yes/no/not tested/version -->
+- Last known working GE-Proton version, if any:
+- First known broken GE-Proton version, if any:
+
+## Launch options
+```text
+<!-- Paste the exact Steam launch options used, e.g. PROTON_LOG=1 %command% -->
+```
 
 ## I confirm:
 - [ ] that I have verified my problem does NOT happen on proton-experimental and ONLY happens on GE-Proton
 - [ ] that I am NOT using the GE-Proton flatpak. (I do not build or provide the GE-Proton flatpak and it is known to have broken codec support.)
 - [ ] that I haven't found an existing compatibility report for this game.
 - [ ] that I have checked whether there are updates for my system available.
+- [ ] that I have tested with a clean prefix or explained why I could not.
 
 For issues with the GE-Proton flatpak, report here:
 https://github.com/flathub/com.valvesoftware.Steam.CompatibilityTool.Proton-GE
 
 <!-- Please add `PROTON_LOG=1 %command%` to the game's launch options and drag
-and drop the generated `$HOME/steam-$APPID.log` into this issue report -->
+and drop the generated `$HOME/steam-$APPID.log` into this issue report. -->
+
+<!-- For media/audio/video regressions, please consider adding a focused WINEDEBUG log if requested by the maintainer, for example:
+PROTON_LOG=1 WINEDEBUG="+seh,+dmo,+mfplat,+quartz,+strmbase,+mfreadwrite,+xaudio2,+mmdevapi,+dsound,+winmm,+pulse,+err" %command%
+-->
 
 ## Symptoms <!-- What's the problem? -->
 


### PR DESCRIPTION
## Summary
- Add distro and desktop session fields to the compatibility report template.
- Add a Proton comparison section for Experimental, bleeding-edge, Valve stable, previous GE-Proton, and first/last broken versions.
- Add explicit launch-options capture and a clean-prefix checkbox.
- Include an optional focused WINEDEBUG hint for media/audio/video regressions when requested.

## Why
Recent reports often need follow-up for the same triage details: whether the issue reproduces on Proton Experimental, which GE-Proton version last worked, exact launch options, clean-prefix status, and Wayland/X11/session context. Capturing those up front should make regression reports easier to compare.

## Verification
- `git diff --check`
- Parsed the template locally and verified the new required sections are present.