### PR TITLE
Fix: skip release creation if already exists

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,20 +31,23 @@ jobs:
       shell: bash
       run: |
         git fetch origin +refs/tags/*:refs/tags/*
-    - name: Create
+       - name: Create Release
       id: create
       shell: bash
-      run: >-
-        gh
-        release create
-        ${{ github.ref_name }}
-        --latest
-        --title "${{ github.ref_name }} Released"
-        --notes-from-tag
-        --verify-tag
+      run: |
+        if gh release view "${{ github.ref_name }}" --repo "${{ github.server_url }}/${{ github.repository }}" &>/dev/null; then
+          echo "Release ${{ github.ref_name }} already exists. Skipping creation."
+        else
+          gh release create "${{ github.ref_name }}" \
+            --latest \
+            --title "${{ github.ref_name }} Released" \
+            --notes-from-tag \
+            --verify-tag \
+            --repo "${{ github.server_url }}/${{ github.repository }}"
+        fi
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
+        
   upload:
     name: Upload
     needs: release


### PR DESCRIPTION
Prevents HTTP 422 tag_name already exists error when workflow is re-run or tag already has a release. Checks if release exists before creating. Uses gh release view to verify existence. Skips creation if release already exists. Allows workflow re-runs without failure.