### PR TITLE
[#627] Add Missing Nvidia & VKLayer Submodule URLs

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -94,3 +94,39 @@
 [submodule "bzip2"]
 	path = bzip2
 	url = https://sourceware.org/git/bzip2.git
+[submodule "nvidia-libs/dxvk-nvapi"]
+	path = nvidia-libs/dxvk-nvapi
+	url = https://github.com/SveSop/dxvk-nvapi.git
+	branch = experimental
+[submodule "nvidia-libs/nvcuda"]
+	path = nvidia-libs/nvcuda
+	url = https://github.com/SveSop/nvcuda.git
+[submodule "nvidia-libs/nvcuda32"]
+	path = nvidia-libs/nvcuda32
+	url = https://github.com/SveSop/nvcuda.git
+	branch = 32bit_only
+[submodule "nvidia-libs/nvenc"]
+	path = nvidia-libs/nvenc
+	url = https://github.com/SveSop/nvenc.git
+[submodule "nvidia-libs/nvenc32"]
+	path = nvidia-libs/nvenc32
+	url = https://github.com/SveSop/nvenc.git
+	branch = old-32-64_version
+[submodule "nvidia-libs/wine-nvml"]
+	path = nvidia-libs/wine-nvml
+	url = https://github.com/Saancreed/wine-nvml.git
+[submodule "nvidia-libs/wine-nvoptix"]
+	path = nvidia-libs/wine-nvoptix
+	url = https://github.com/SveSop/wine-nvoptix.git
+[submodule "vklayers/pyroveil"]
+	path = vklayers/pyroveil
+	url = https://github.com/HansKristian-Work/pyroveil.git
+[submodule "vklayers/Vulkan-Utility-Libraries"]
+	path = vklayers/Vulkan-Utility-Libraries
+	url = https://github.com/KhronosGroup/Vulkan-Utility-Libraries.git
+[submodule "vklayers/low_latency_layer"]
+	path = vklayers/low_latency_layer
+	url = https://github.com/Korthos-Software/low_latency_layer.git
+[submodule "vklayers/vkbasalt"]
+	path = vklayers/vkBasalt
+	url = https://github.com/DadSchoorse/vkBasalt.git


### PR DESCRIPTION
Fix builds with the enabled-by-default vklayer & nvidia-libs components by adding the missing submodule urls & branches that they require.

All the target commits match up with the CachyOS source that these were pulled from - except for `wine-nvml`. Cachy has it fixed to `40fc2fc` while the latest commit(what this commit sets) is `a1a7d8f`.

Verified by running `make redist` locally, running GH actions for addtl proof:
* https://github.com/prikhi/proton-ge-custom/actions/runs/29208183387 (failed in post-build `mv` command cause my branch has a `/` in it)
* https://github.com/prikhi/proton-ge-custom/actions/runs/29208177973

Closes #627 