### PR TITLE
Remove forced PROTON_NO_STEAMINPUT=1 when wine-wayland driver is enabled.

### DIFF
--- a/proton
+++ b/proton
@@ -2359,22 +2359,10 @@ class Session:
             self.env.setdefault("WINE_MOVE_HACK", "1")
             # It is not possible for winewayland to support xalia since
             # there is no way to position toplevel surfaces dynamically in wayland
-            self.env["PROTON_USE_XALIA"] = "0"
-            # Never expose Steam's desktop virtual controller on winewayland.
-            self.env["PROTON_NO_STEAMINPUT"] = "1"
+            self.env["PROTON_USE_XALIA"] = "1"
             # Steam cannot track native Wayland window focus, so keep it from
             # falling back to the global desktop controller layout.
             self.force_steam_input_appid = True
-            # Disable other steam input related stuff
-            if nonzero(self.env["PROTON_NO_STEAMINPUT"]):
-                # When steam input is disabled we need the ignored controllers to work again
-                if "SDL_GAMECONTROLLER_IGNORE_DEVICES" in self.env:
-                    del self.env["SDL_GAMECONTROLLER_IGNORE_DEVICES"]
-                # Some other steam input related options we need to remove
-                if "SteamVirtualGamepadInfo" in self.env:
-                    del self.env["SteamVirtualGamepadInfo"]
-                if "SDL_GAMECONTROLLER_ALLOW_STEAM_VIRTUAL_GAMEPAD" in self.env:
-                    del self.env["SDL_GAMECONTROLLER_ALLOW_STEAM_VIRTUAL_GAMEPAD"]
             # FIXME: temporary workaround for libxkbcommon's current integration
             self.env.setdefault("XLOCALEDIR", g_proton.dist_dir + "share/X11/locale")
             # Some strange bug with X displays. I have a hunch it is caused by ffmpeg but it's not logging anything...


### PR DESCRIPTION
Steam Input always worked on Wayland applications, it just never applied the profile.

Ever since GE-PROTON11-3 there is a  "force steam input appid" call or something, and now there is no need to **force** users to use SDL when they just want Wayland support.

If you need proof this is the case, i can show that it does work.
Edit: [here is footage of it running.](https://youtu.be/Lr25-ebhLVE?si=sStii_lI-n2w33L3)