### PR TITLE
patches: fix NULL caption crash in Star Citizen MessageBoxExA hook (#657)

### DIFF
--- a/patches/game-patches/silence-starcitizen-unsupported-os.patch
+++ b/patches/game-patches/silence-starcitizen-unsupported-os.patch
@@ -14,7 +14,7 @@ index 8d9adce..3ae5e23 100644
  {
      MSGBOXPARAMSA msgbox;
  
-+    if (strcmp(title, "Star Citizen") == 0 && strcmp(text, sc_unsupported) == 0)
++    if (title && text && strcmp(title, "Star Citizen") == 0 && strcmp(text, sc_unsupported) == 0)
 +            return 0;
 +
      msgbox.cbSize = sizeof(msgbox);


### PR DESCRIPTION
Fixes #657.

The existing `silence-starcitizen-unsupported-os` game-patch hooks
`MessageBoxExA` and calls `strcmp(title, "Star Citizen")` / `strcmp(text, ...)`
without checking either pointer for NULL. Passing NULL for the caption is legal
— per MSDN, "If this parameter is NULL, the default title Error is used" — so
any app calling `MessageBoxA(NULL, msg, NULL, ...)` hits an access violation
inside the hook. Stock Proton has no such patch and is unaffected.

This guards `title` and `text` for NULL before the `strcmp` calls. A real
"Star Citizen" match requires both to be non-NULL anyway, so the workaround's
behavior is unchanged; every other app stops crashing.

This only edits the existing patch's added hunk (the `if` condition) — no
context lines change, so offsets are unchanged and it applies against the same
pinned wine submodule as before. No `protonprep-valve-staging.sh` change is
needed since the patch is already registered.

Reproducer (from #657):

    #include <windows.h>
    int WINAPI WinMain(HINSTANCE h, HINSTANCE p, LPSTR cmd, int show)
    {
        MessageBoxA(NULL, "does this crash?", NULL, MB_OK);
        return 0;
    }

| build | result |
|---|---|
| GE-Proton11-3 (before) | EXCEPTION_ACCESS_VIOLATION, exit 5 |
| this patch | exits 0, dialog shows normally |
| stock Proton / system wine | exits 0 (unaffected) |