### PR TITLE
Games to add to the DS5 -> DS4 spoofing list

### DIFF
--- a/proton
+++ b/proton
@@ -1829,8 +1829,26 @@ class Session:
 				# the DS4 properly, it's debatable if this entry should make it into the
 				# final commit.
                 "208650",  # Batman: Arkham Knight
+                # The enhanced edition of Little nightmares has full support for the
+                # DualSense. This entry is here in case anyone prefers the original and
+                # still wants to use the DualSense.
+                "424840",  # Little Nightmares (Original)
+                "996580",  # Spyro Reignited Trilogy
                 ]:
             self.env["PROTON_SONY_DUALSENSE_AS_DUALSHOCK4"] = "1"
+
+        # These games have proper proper Sony button mappings and glyohs, but do not
+        # support the DualSense or the DS4 v2. In both cases, a DS4 v1 will be spoofed
+        # for proper functionality.
+        # Addendum: I do not know if this combination of env variables will have the
+        # desired effect if a DS4 v2 is connected, or if it only works with a DualSense.
+        # Feedback on this would be appreciated, as I lack a DS4 v2 to test with.
+        if appid in [
+                "731490",  # Crash Bandicoot N. Sane Trilogy
+                "638970",  # Yakuza 0
+                ]:
+            self.env["PROTON_SONY_DUALSENSE_AS_DUALSHOCK4"] = "1"
+            self.env["PROTON_SONY_DUALSHOCK4_V2_AS_V1"] = "1"
 
         # These games rely on Steam Input action manifests. Expose XInput through
         # lsteamclient's standalone Steam Input implementation. The fallback detects

--- a/proton
+++ b/proton
@@ -1823,7 +1823,10 @@ class Session:
                 "1151640",  # Horizon Zero Dawn Complete Edition
                 "1172710",  # Dune Awakening
                 "330390",  # Grandia II
+                "731490",  # Crash Bandicoot N'Sane Trilogy
                 "253230",  # A Hat in Time
+                "638970",  # Yakuza 0
+                "612880",  # Wolfenstein II: The New Colossus
                 # Batman Arkham Knight turns out to ship with a flawed libScePad_x64.dll
                 # that prevents both the DS4 v1 and v2 from working. Replacing it with
                 # one from another game fixed the issue and let both DS4 models work

--- a/proton
+++ b/proton
@@ -1836,27 +1836,17 @@ class Session:
                 # still wants to use the DualSense.
                 "424840",  # Little Nightmares (Original)
                 "996580",  # Spyro Reignited Trilogy
-                ]:
-            self.env["PROTON_SONY_DUALSENSE_AS_DUALSHOCK4"] = "1"
-
-        # These games have proper proper Sony button mappings and glyohs, but do not
-        # support the DualSense or the DS4 v2. In both cases, a DS4 v1 will be spoofed
-        # for proper functionality.
-        # Addendum: I do not know if this combination of env variables will have the
-        # desired effect if a DS4 v2 is connected, or if it only works with a DualSense.
-        # Feedback on this would be appreciated, as I lack a DS4 v2 to test with.
-        if appid in [
-                "731490",  # Crash Bandicoot N. Sane Trilogy
-                "638970",  # Yakuza 0
-                ]:
-            self.env["PROTON_SONY_DUALSENSE_AS_DUALSHOCK4"] = "1"
-                "731490",  # Crash Bandicoot N'Sane Trilogy
+                # Recommended by rjbs91. I don't have Greedfall, so I would recommend
+                # testing it's support; whether it supports the DS4 v2 or only the v1.
+                # rjbs91 claims it has proper button mappings and glyphs.
                 ]:
             self.env["PROTON_SONY_DUALSENSE_AS_DUALSHOCK4"] = "1"
 
         # Some games only support DS4 v1
         if appid in [
                 "731490",  # Crash Bandicoot N'Sane Trilogy
+                "638970",  # Yakuza 0
+                "612880",  # Wolfenstein II: The New Colossus
                 ]:
             self.env["PROTON_SONY_DUALSHOCK4_V2_AS_V1"] = "1"
 

--- a/proton
+++ b/proton
@@ -1839,6 +1839,7 @@ class Session:
                 # Recommended by rjbs91. I don't have Greedfall, so I would recommend
                 # testing it's support; whether it supports the DS4 v2 or only the v1.
                 # rjbs91 claims it has proper button mappings and glyphs.
+                "606880",  # Greedfall
                 ]:
             self.env["PROTON_SONY_DUALSENSE_AS_DUALSHOCK4"] = "1"
 

--- a/proton
+++ b/proton
@@ -1822,6 +1822,13 @@ class Session:
                 "1172710",  # Dune Awakening
                 "330390",  # Grandia II
                 "253230",  # A Hat in Time
+                # Batman Arkham Knight turns out to ship with a flawed libScePad_x64.dll
+                # that prevents both the DS4 v1 and v2 from working. Replacing it with
+                # one from another game fixed the issue and let both DS4 models work
+                # properly. Because this means the game needs to be modded to support
+				# the DS4 properly, it's debatable if this entry should make it into the
+				# final commit.
+                "208650",  # Batman: Arkham Knight
                 ]:
             self.env["PROTON_SONY_DUALSENSE_AS_DUALSHOCK4"] = "1"
 

--- a/proton
+++ b/proton
@@ -1821,6 +1821,7 @@ class Session:
                 "1151640",  # Horizon Zero Dawn Complete Edition
                 "1172710",  # Dune Awakening
                 "330390",  # Grandia II
+                "253230",  # A Hat in Time
                 ]:
             self.env["PROTON_SONY_DUALSENSE_AS_DUALSHOCK4"] = "1"
 


### PR DESCRIPTION
Even though A Hat in Time has generic controller support, and sees the DualSense as a generic controller, it's able to directly use a DS4 with proper mappings and button glyphs, so add it to the spoofing list.