### PR TITLE
patches: use relative library path for low_latency_layer

### DIFF
--- a/patches/low_latency_layer/0001-use-relative-library-path.patch
+++ b/patches/low_latency_layer/0001-use-relative-library-path.patch
@@ -1,0 +1,13 @@
+diff --git a/low_latency_layer.json.in b/low_latency_layer.json.in
+index 31e087c..fc960a2 100644
+--- a/low_latency_layer.json.in
++++ b/low_latency_layer.json.in
+@@ -3,7 +3,7 @@
+     "layer": {
+         "name": "VK_LAYER_KORTHOS_low_latency",
+         "type": "GLOBAL",
+-        "library_path": "@CMAKE_INSTALL_FULL_LIBDIR@/libVkLayer_KORTHOS_LowLatency.so",
++        "library_path": "libVkLayer_KORTHOS_LowLatency.so",
+         "api_version": "1.3.0",
+         "implementation_version": "3",
+         "description": "Input latency reduction layer",

--- a/patches/protonprep-valve-staging.sh
+++ b/patches/protonprep-valve-staging.sh
@@ -47,6 +47,13 @@ apply_all_in_dir() {
     apply_all_in_dir "../patches/wineopenxr/"
     popd
 
+    pushd vklayers/low_latency_layer
+    git reset --hard HEAD
+    git clean -xdf
+    echo "LOW_LATENCY_LAYER: use relative library path"
+    apply_all_in_dir "../../patches/low_latency_layer"
+    popd
+
 ### END PREP SECTION ###
 
     git checkout steam_helper


### PR DESCRIPTION
Currently, the implicit layer is shipped like this:

```
"name": "VK_LAYER_KORTHOS_low_latency",
"type": "GLOBAL",
"library_path": "/mnt/Storage/Projects/Development/proton/build/dst-low_latency_layer-x86_64/lib/x86_64-linux-gnu/libVkLayer_KORTHOS_LowLatency.so",
```

And it prevents the layer from loading when using `LOW_LATENCY_LAYER=1`. This patch makes the path relative like the others.