### PR TITLE
Fix for NASCAR '25 crashing on startup

### DIFF
--- a/patches/game-patches/nascar25-protector.patch
+++ b/patches/game-patches/nascar25-protector.patch
@@ -1,0 +1,68 @@
+--- a/dlls/ntdll/unix/signal_x86_64.c
++++ b/dlls/ntdll/unix/signal_x86_64.c
+@@ -2816,6 +2816,7 @@
+ #if defined(__APPLE__) || defined(__linux__)
+ 
+ static BOOL use_eos_syscall_hack;
++static BOOL use_nascar25_hack;
+ 
+ /**********************************************************************
+  *		sigsys_handler
+@@ -2826,6 +2827,7 @@
+ static void sigsys_handler( int signal, siginfo_t *siginfo, void *sigcontext )
+ {
+     extern const void *__wine_syscall_dispatcher_prolog_end_ptr;
++    static int n25_repaired;
+     ucontext_t *ucontext = init_handler( sigcontext );
+     struct syscall_frame *frame = get_syscall_frame();
+ 
+@@ -2867,6 +2869,41 @@
+     }
+ #endif
+ 
++    /* NASCAR 25's protected loader corrupts its VM state before its first direct
++     * NtProtectVirtualMemory syscall under Wine. Restore the known-good state once. */
++    if (use_nascar25_hack && !n25_repaired && RAX_sig(ucontext) == 0x50 &&
++        (*(ULONG64 *)R8_sig(ucontext) >> 48) == 0xf63c &&
++        RIP_sig(ucontext) - *(ULONG64 *)(RSP_sig(ucontext) + 0x60) == 0x66ddf28)
++    {
++        const ULONG64 key0 = 0xf63c941b3c2d1603ULL;
++        const ULONG64 key1 = 0xd400941204241403ULL;
++        const ULONG64 key2 = 0x4400141204000401ULL;
++        const ULONG64 key3 = 0x223c000938090200ULL;
++        ULONG64 image_base = RIP_sig(ucontext) - 0x7373b87;
++
++        *(ULONG64 *)RDX_sig(ucontext) = image_base + 0x1000;
++        *(ULONG64 *)R8_sig(ucontext) ^= key0;
++        *(ULONG64 *)(RBP_sig(ucontext) - 0x11c0) = image_base + 0x1000;
++        *(ULONG64 *)(RBP_sig(ucontext) - 0x1120) ^= key0;
++        *(ULONG64 *)(RBP_sig(ucontext) - 0x1100) ^= key0;
++        *(ULONG64 *)(RBP_sig(ucontext) - 0x08) ^= key3;
++        *(ULONG64 *)(RBP_sig(ucontext) + 0x48) ^= key1;
++        *(ULONG64 *)(RBP_sig(ucontext) + 0x70) ^= key2;
++        *(ULONG64 *)(RBP_sig(ucontext) + 0x78) ^= key2;
++        *(ULONG64 *)(RBP_sig(ucontext) + 0x98) ^= key3;
++        *(ULONG64 *)(RBP_sig(ucontext) + 0xa8) ^= key1;
++        *(ULONG64 *)(RBP_sig(ucontext) + 0xb0) ^= key3;
++        *(ULONG64 *)(RBP_sig(ucontext) + 0xc0) ^= key1;
++        *(ULONG64 *)(RBP_sig(ucontext) + 0xc8) ^= key3;
++        RBX_sig(ucontext) ^= key1;
++        RSI_sig(ucontext) ^= key0;
++        RDI_sig(ucontext) ^= 0x1400100000240001ULL;
++        R13_sig(ucontext) ^= key2;
++        R14_sig(ucontext) ^= key2;
++        R15_sig(ucontext) ^= 0x101000000001ULL;
++        n25_repaired = 1;
++    }
++
+     frame->rip = RIP_sig(ucontext) + 0xb;
+     frame->rcx = RIP_sig(ucontext);
+     frame->eflags = EFL_sig(ucontext);
+@@ -3104,6 +3141,7 @@
+             /* We don't unset the env since child processes also need to inherit the same syscall hack */
+             use_eos_syscall_hack = (env = getenv("PROTON_SYSCALL_HACK")) && !strcmp(env, "1");
+             if (use_eos_syscall_hack) ERR_(seh)("Using EAC bootstrapper (EOS) syscall workaround!\n");
++            use_nascar25_hack = (env = getenv("SteamGameId")) && !strcmp(env, "3873970");
+         }
+     }
+ #endif

--- a/patches/protonprep-valve-staging.sh
+++ b/patches/protonprep-valve-staging.sh
@@ -258,6 +258,9 @@ apply_all_in_dir() {
     echo "WINE: -GAME FIXES- make MapleStory launch: accept SPI_SETSTICKYKEYS/SPI_SETFILTERKEYS"
     apply_patch "../patches/game-patches/maplestory-spi-stickykeys-filterkeys.patch"
 
+    echo "WINE: -GAME FIXES- repair NASCAR 25 protected loader state"
+    apply_patch "../patches/game-patches/nascar25-protector.patch"
+
 ### END GAME PATCH SECTION ###
 
 ### (2-5) WINE HOTFIX/BACKPORT SECTION ###


### PR DESCRIPTION
This patch fixes NASCAR '25's protector breaking (again) under Proton. Should be playable again.
An update to the game in December broke the patches that were already in place and had been upstreamed to Proton: they changed behaviors intentionally again, though to fix this properly apparently involves would require a full set of patches to upstream WINE which I cannot do as LLM-generated code isn't allowed there.
# LLM Disclosure
This game was debugged and patch was generated by AI - model was gpt-5.6-sol.