### PR TITLE
winex11: make WINE_LAYERED_OVERLAY_INPUT_SHAPE=0 mean click-through

### DIFF
--- a/patches/game-patches/layered-overlay-wine.patch
+++ b/patches/game-patches/layered-overlay-wine.patch
@@ -21,7 +21,9 @@ instead of through XGetPixel, and in ALPHA mode samples on a clock
 (WINE_LAYERED_OVERLAY_SHAPE_INTERVAL, default 32 ms) rather than once per present - the input
 region follows UI layout, not frame rate. SHAPE mode still samples per present, where the
 readback drives the visible bounding shape. WINE_LAYERED_OVERLAY_INPUT_SHAPE=0 skips the input
-shape altogether. 1080p full-screen overlay on XWayland: 11.26 -> 1.16 ms per present, with a
+shape, and the readback that feeds it, altogether: with it off the window keeps the stock
+empty-input-shape pass-through rather than falling back to taking input over its whole
+rectangle. 1080p full-screen overlay on XWayland: 11.26 -> 1.16 ms per present, with a
 bit-identical block mask.
 
 Based on the original TBH-specific XShape patch by Solarisfire; generalised, flicker fixed,
@@ -30,12 +32,13 @@ diff --git a/dlls/winex11.drv/x11drv.h b/dlls/winex11.drv/x11drv.h
 index 9436f35e1c..5975c860b6 100644
 --- a/dlls/winex11.drv/x11drv.h
 +++ b/dlls/winex11.drv/x11drv.h
-@@ -367,6 +367,8 @@ struct x11drv_escape_get_drawable
+@@ -367,6 +367,9 @@ struct x11drv_escape_get_drawable
  };
  
  extern BOOL needs_offscreen_rendering( HWND hwnd );
 +extern BOOL layered_overlay_shape_enabled(void);
 +extern BOOL layered_overlay_alpha_enabled(void);
++extern BOOL layered_overlay_input_shape_enabled(void);
  extern void set_dc_drawable( HDC hdc, Drawable drawable, const RECT *rect, int mode );
  extern Drawable get_dc_drawable( HDC hdc, RECT *rect );
  extern HRGN get_dc_monitor_region( HWND hwnd, HDC hdc );
@@ -98,7 +101,7 @@ index 614450e72d6..8cb0f0d2b52 100644
 +
 +/* WINE_LAYERED_OVERLAY_INPUT_SHAPE=0 skips the ALPHA-mode input shape, and the readback
 + * that feeds it, for overlays that never need to be clicked. */
-+static BOOL layered_overlay_input_shape_enabled(void)
++BOOL layered_overlay_input_shape_enabled(void)
 +{
 +    static int enabled = -1;
 +    if (enabled == -1)
@@ -518,11 +521,13 @@ index 63a8536c71..fa0aafe4d4 100644
  
      return (CWSaveUnder | CWColormap | CWBorderPixel | CWBackPixel |
              CWEventMask | CWBitGravity | CWBackingStore);
-@@ -596,23 +597,24 @@ static void sync_window_input_shape( struct x11drv_win_data *data )
+@@ -596,23 +597,26 @@ static void sync_window_input_shape( struct x11drv_win_data *data )
  {
  #ifdef HAVE_LIBXSHAPE
      DWORD ex_style = NtUserGetWindowLongW( data->hwnd, GWL_EXSTYLE );
-+    BOOL overlay = layered_overlay_shape_enabled() || layered_overlay_alpha_enabled();
++    /* ALPHA mode's input shape comes from the readback; with it off keep the stock pass-through */
++    BOOL overlay = layered_overlay_shape_enabled() ||
++                   (layered_overlay_alpha_enabled() && layered_overlay_input_shape_enabled());
      char const *sgi;
  
      if (!data->whole_window) return;


### PR DESCRIPTION
## Summary

`WINE_LAYERED_OVERLAY_INPUT_SHAPE=0` currently does the opposite of what it says. It is
documented as "skip the input shape", and `update_layered_overlay_shape()` honours that by
skipping the readback — but `sync_window_input_shape()` sends every overlay window down the
non-transparent branch:

```c
if ((ex_style & WS_EX_TRANSPARENT) && !overlay)
    /* empty input shape -> mouse passes through */
else
    XShapeCombineMask( ..., ShapeInput, 0, 0, None, ShapeSet );  /* whole window takes input */
```

With `overlay` true you always land in the `else`, which leaves the input region at the X11
default — **the entire window**. Nothing narrows it afterwards, so in ALPHA mode a
`WS_EX_TRANSPARENT` overlay the size of the screen becomes a full-area input sink sitting on
top of everything, instead of being click-through.

SHAPE mode is deliberately untouched: there the sampler drives `ShapeBounding`, never
`ShapeInput`, and the window genuinely needs to keep taking input over its whole rectangle.
So only ALPHA mode changes:

```c
BOOL overlay = layered_overlay_shape_enabled() ||
               (layered_overlay_alpha_enabled() && layered_overlay_input_shape_enabled());
```

## Where it showed up

Reported in #752 (Birdwatching Notebook, AppID 4111370, KWin/XWayland): notable mouse input
latency while dragging, the pointer sticking at the window border when trying to leave, and
the cursor keeping the in-game shape over other X11 windows. Their log shows
`reset input shape to default` — the TRACE from the whole-window branch — confirming the
window really is taking input everywhere rather than being click-through.

The reporter in #712 never hit this because their Hyprland rules (`xray` / `no_focus` /
`no_follow_mouse`) were doing the pass-through at the compositor level, so Wine's input
region never mattered.

## Behaviour change, stated plainly

With `WINE_LAYERED_OVERLAY_ALPHA=1 WINE_LAYERED_OVERLAY_INPUT_SHAPE=0`, a
`WS_EX_TRANSPARENT` overlay is now genuinely click-through. That is the documented intent of
the flag, and it is the only combination whose behaviour changes.

The trade is worth naming: an app that polls `GetCursorPos()` to decide when to drop
`WS_EX_TRANSPARENT` can now go stale, because the cursor is no longer over an input-taking
X11 window — the condition the pre-existing bug-27151 hack in this same function describes.
That is acceptable for what the flag is for ("overlays that never need to be clicked, or
whose compositor already passes input through"), and it is strictly better than the current
behaviour, where the overlay silently swallows input across the whole screen. Defaults are
unchanged: with `INPUT_SHAPE` unset or `=1`, nothing about this differs from today.

## Testing

- **Exhaustive branch matrix.** The real `sync_window_input_shape()` text and the three env
  helpers were extracted from the git objects and compiled into two harnesses — one from the
  shipped code, one from this change — then run over 2916 environment combinations, one
  process per combination so the `static` caching in the helpers is exercised the way it is
  at runtime. Values include `""`, `"2"`, `"yes"`, `"00"`, `" 1"`, `"-1"` to cover `atoi`
  behaviour. Both harnesses agree with an independent model on all 2916; 80 concrete
  combinations differ between shipped and fixed, and they collapse to exactly one semantic
  class: `ALPHA on + INPUT_SHAPE off + WS_EX_TRANSPARENT + not the hardcoded AppID`. Of the
  2836 combinations that should not change, none did.
- **Compiles clean under the wine build.** `dlls/winex11.drv/{init,window}.o` built in a real
  configured wine tree at the pinned submodule commit, with `EXTRACFLAGS="-Wall -Werror
  -Wdeclaration-after-statement"` on top of wine's own warning set: 0 warnings. The
  unmodified files, reverted to the current tree state, build with 0 warnings under the same
  flags — so this adds none.
- `HAVE_LIBXSHAPE`, `HAVE_X11_EXTENSIONS_XSHM_H`, `HAVE_SYS_SHM_H` and `HAVE_SYS_IPC_H` were
  all confirmed present in the generated `config.h`, so the changed code is genuinely
  compiled rather than sitting inside a disabled `#ifdef`.
- The patch applies cleanly to the pinned wine and produces a byte-identical tree to the one
  that was tested. It is reversible and detects reapplication.
- Applying the header hunk without the `init.c` hunk fails loudly
  (`static declaration ... follows non-static declaration`) rather than building something
  subtly wrong — worth knowing if the patch ever applies with fuzz.

## Known limitation

`get_window_attributes()` in the same file keeps its own two-term `overlay`, so it still
adds `PointerMotionMask` and friends for these windows. That is inert today — an empty
`ShapeInput` region means the window receives no pointer events regardless of `event_mask`,
and both callers of `get_window_attributes()` call `sync_window_input_shape()` immediately
afterwards in the same function. I left it alone to keep the diff minimal, since changing
`event_mask` also touches `EnterWindowMask` behaviour and I have no way to test that here.
Flagging it so it is a deliberate choice rather than an oversight.

As with #716, I could not validate this end to end against a live overlay game — I no longer
have TBH installed and don't own the game in #752. I'll ask the reporter there to confirm on
the setup that surfaced it.
