### PR TITLE
ntdll: implement IOCTL_SERIAL_GET_DTRRTS for serial devices

### DIFF
--- a/patches/proton/0001-ntdll-Implement-IOCTL_SERIAL_GET_DTRRTS-for-serial-dev.patch
+++ b/patches/proton/0001-ntdll-Implement-IOCTL_SERIAL_GET_DTRRTS-for-serial-dev.patch
@@ -1,0 +1,56 @@
+From 9a8d13eeb6ef463b99397304016d48561d194445 Mon Sep 17 00:00:00 2001
+From: Haeris31 <279492726+Haeris31@users.noreply.github.com>
+Date: Fri, 11 Sep 2026 07:54:21 +0200
+Subject: [PATCH] ntdll: Implement IOCTL_SERIAL_GET_DTRRTS for serial devices.
+
+Qt's QSerialPort::pinoutSignals() (used by MOZA Device Service and other
+Qt based device tools) issues IOCTL_SERIAL_GET_DTRRTS right after opening
+a COM port. Wine returned STATUS_INVALID_PARAMETER from the default branch,
+which Qt latches as a sticky UnsupportedOperationError; the application
+then never writes to the port. Report the DTR/RTS line state via TIOCMGET,
+as SERIAL_DTR_STATE / SERIAL_RTS_STATE, which is what the ioctl returns on
+Windows.
+---
+ dlls/ntdll/unix/serial.c | 26 ++++++++++++++++++++++++++
+ 1 file changed, 26 insertions(+)
+
+diff --git a/dlls/ntdll/unix/serial.c b/dlls/ntdll/unix/serial.c
+index 7a79dd0..8ed4aeb 100644
+--- a/dlls/ntdll/unix/serial.c
++++ b/dlls/ntdll/unix/serial.c
+@@ -1336,6 +1336,32 @@ NTSTATUS serial_DeviceIoControl( HANDLE device, HANDLE event, PIO_APC_ROUTINE ap
+         }
+         else status = STATUS_INVALID_PARAMETER;
+         break;
++    case IOCTL_SERIAL_GET_DTRRTS:
++        if (out_buffer && out_size == sizeof(DWORD))
++        {
++#ifdef TIOCMGET
++            int mstat;
++            if (ioctl(fd, TIOCMGET, &mstat) == -1)
++            {
++                WARN("TIOCMGET err %s\n", strerror(errno));
++                status = errno_to_status( errno );
++            }
++            else
++            {
++                DWORD *state = out_buffer;
++                *state = 0;
++                if (mstat & TIOCM_DTR) *state |= SERIAL_DTR_STATE;
++                if (mstat & TIOCM_RTS) *state |= SERIAL_RTS_STATE;
++                TRACE("DTR/RTS state %08x\n", (unsigned int)*state);
++                status = STATUS_SUCCESS;
++                sz = sizeof(DWORD);
++            }
++#else
++            status = STATUS_NOT_SUPPORTED;
++#endif
++        }
++        else status = STATUS_INVALID_PARAMETER;
++        break;
+     case IOCTL_SERIAL_GET_PROPERTIES:
+         if (out_buffer && out_size == sizeof(SERIAL_COMMPROP))
+         {
+-- 
+2.55.0
+

--- a/patches/protonprep-valve-staging.sh
+++ b/patches/protonprep-valve-staging.sh
@@ -427,6 +427,9 @@ apply_all_in_dir() {
     echo "WINE: -PERF- read QueryPerformanceCounter from the TSC in user mode (DCS World: 39 -> 62 FPS)"
     apply_patch "../patches/proton/0001-ntdll-Read-QueryPerformanceCounter-from-the-TSC-in-us.patch"
 
+    echo "WINE: implement IOCTL_SERIAL_GET_DTRRTS (Qt serial device tools, e.g. MOZA Cockpit)"
+    apply_patch "../patches/proton/0001-ntdll-Implement-IOCTL_SERIAL_GET_DTRRTS-for-serial-dev.patch"
+
     echo "WINE: -HOTFIX- Implement GE-Proton ffmpeg + winedmo only video playback rework patches"
     apply_all_in_dir "../patches/ge-video-rework/"
 


### PR DESCRIPTION
While trying to get MOZA Cockpit, the configuration tool for MOZA flight sim hardware, working under Proton, I found that it opens the device's COM port and immediately calls `IOCTL_SERIAL_GET_DTRRTS`.

The call comes from Qt's `QSerialPort::pinoutSignals()`, which queries the modem control lines after opening the port.

Wine currently does not implement this ioctl. `serial_DeviceIoControl()` falls through to the default case and returns `STATUS_INVALID_PARAMETER`.

Qt then leaves the port in an `UnsupportedOperationError` state. In MOZA Cockpit this prevents any subsequent writes to the device: the service repeatedly logs `write skipped, port error`, while the base remains shown as disconnected even though the serial port itself opened successfully.

This patch implements `IOCTL_SERIAL_GET_DTRRTS` in `serial_DeviceIoControl()`.

It uses `TIOCMGET` to query the modem control state and maps the result to `SERIAL_DTR_STATE` and `SERIAL_RTS_STATE`. On platforms where `TIOCMGET` is not available, the ioctl returns `STATUS_NOT_SUPPORTED`.

The ioctl name was already present in Wine's debug table, but the actual handler was missing.

The change is entirely in `dlls/ntdll/unix/serial.c`; there are no Windows-side changes.

## Results

Tested with:

* MOZA Cockpit 1.1.4.36
* MOZA AB9 base
* USB CDC ACM device (`/dev/ttyACM0`)
* GE-Proton11-3
* `umu-launcher`
* DCS World

Before the patch:

* the serial port opened successfully;
* `IOCTL_SERIAL_GET_DTRRTS` returned an error;
* MOZA Cockpit stopped sending data to the port;
* the base remained shown as disconnected.

After the patch:

* the serial initialization completes;
* the base is detected as connected;
* force feedback presets are loaded correctly;
* the settings are applied and work in DCS World.

I also checked Wine master, wine-staging and the current GE Wine submodule and could not find an implementation of this ioctl. I did not find an existing Wine bug or merge request covering it either.

## Build/testing

The patch applies cleanly to the current Wine submodule used by GE-Proton.

For testing, I rebuilt only the Unix `ntdll` binaries (`x86_64-unix` and `i386-unix`) from the GE-Proton11-3 sources and replaced the corresponding release binaries.

That was sufficient to exercise this change since the implementation is entirely on the Unix side.

I have not tested it through a complete GE-Proton build.
