### PR TITLE
crypt32: accept the current 88-byte CERT_CHAIN_ENGINE_CONFIG (fixes Warcraft III: Reforged 3.0 "check your VPN" login error)

### DIFF
--- a/patches/protonprep-valve-staging.sh
+++ b/patches/protonprep-valve-staging.sh
@@ -318,6 +318,9 @@ apply_all_in_dir() {
     echo "WINE: -HOTFIX- Reject unsupported NCrypt-only private-key requests"
     apply_patch "../patches/wine-hotfixes/pending/crypt32-reject-ncrypt-only-private-keys.patch"
 
+    echo "WINE: -HOTFIX- Accept the current 88-byte CERT_CHAIN_ENGINE_CONFIG (Warcraft III: Reforged 3.0 login)"
+    apply_patch "../patches/wine-hotfixes/pending/crypt32-accept-88-byte-cert-chain-engine-config.patch"
+
     echo "WINE: -HOTFIX- Add GetFileVersionInfoByHandle version export stub"
     apply_patch "../patches/wine-hotfixes/pending/version-GetFileVersionInfoByHandle-stub.patch"
 

--- a/patches/wine-hotfixes/pending/crypt32-accept-88-byte-cert-chain-engine-config.patch
+++ b/patches/wine-hotfixes/pending/crypt32-accept-88-byte-cert-chain-engine-config.patch
@@ -1,0 +1,78 @@
+crypt32: Accept the current (88-byte) CERT_CHAIN_ENGINE_CONFIG in CertCreateCertificateChainEngine().
+
+Backport of upstream Wine (11.6):
+  02bb0a34 crypt32: Trace CERT_CHAIN_ENGINE_CONFIG fields in CertCreateCertificateChainEngine().
+  eef8e97d crypt32: Don't access CERT_CHAIN_ENGINE_CONFIG::dwExclusiveFlags without checking size.
+  c7cc9be8 crypt32: Also accept CERT_CHAIN_ENGINE_CONFIG without dwExclusiveFlags.
+plus the include/wincrypt.h dwExclusiveFlags field they depend on.
+
+Fixes Warcraft III: Reforged 3.0 (September 2026 expansion, new ClientSdk.dll)
+failing Battle.net login with "There was an error in handling the request.
+Please check your VPN". ClientSdk.dll passes the current Windows
+CERT_CHAIN_ENGINE_CONFIG (88 bytes on x64, includes dwExclusiveFlags); the
+Proton wine only accepted 64 and 80 bytes and returned E_INVALIDARG, so the
+game could not validate the server certificate chain.
+
+--- a/dlls/crypt32/chain.c	2026-08-26 13:49:48.000000000 -0300
++++ b/dlls/crypt32/chain.c	2026-09-12 18:47:44.438316522 -0300
+@@ -221,6 +221,22 @@
+     DWORD       CycleDetectionModulus;
+ } CERT_CHAIN_ENGINE_CONFIG_NO_EXCLUSIVE_ROOT;
+ 
++typedef struct _CERT_CHAIN_ENGINE_CONFIG_NO_EXCLUSIVE_FLAGS
++{
++    DWORD       cbSize;
++    HCERTSTORE  hRestrictedRoot;
++    HCERTSTORE  hRestrictedTrust;
++    HCERTSTORE  hRestrictedOther;
++    DWORD       cAdditionalStore;
++    HCERTSTORE *rghAdditionalStore;
++    DWORD       dwFlags;
++    DWORD       dwUrlRetrievalTimeout;
++    DWORD       MaximumCachedCertificates;
++    DWORD       CycleDetectionModulus;
++    HCERTSTORE  hExclusiveRoot;
++    HCERTSTORE  hExclusiveTrustedPeople;
++} CERT_CHAIN_ENGINE_CONFIG_NO_EXCLUSIVE_FLAGS;
++
+ BOOL WINAPI CertCreateCertificateChainEngine(PCERT_CHAIN_ENGINE_CONFIG pConfig,
+  HCERTCHAINENGINE *phChainEngine)
+ {
+@@ -228,12 +244,23 @@
+ 
+     TRACE("(%p, %p)\n", pConfig, phChainEngine);
+ 
+-    if (pConfig->cbSize != sizeof(CERT_CHAIN_ENGINE_CONFIG_NO_EXCLUSIVE_ROOT)
+-     && pConfig->cbSize != sizeof(CERT_CHAIN_ENGINE_CONFIG))
++    TRACE("cbSize %lu\n", pConfig->cbSize);
++    if (pConfig->cbSize != sizeof(CERT_CHAIN_ENGINE_CONFIG_NO_EXCLUSIVE_ROOT) &&
++        pConfig->cbSize != sizeof(CERT_CHAIN_ENGINE_CONFIG_NO_EXCLUSIVE_FLAGS) &&
++        pConfig->cbSize != sizeof(CERT_CHAIN_ENGINE_CONFIG))
+     {
+         SetLastError(E_INVALIDARG);
+         return FALSE;
+     }
++
++    if (pConfig->cbSize == sizeof(CERT_CHAIN_ENGINE_CONFIG))
++    {
++        TRACE("hExclusiveRoot %p\n", pConfig->hExclusiveRoot);
++        TRACE("hExclusiveTrustedPeople %p\n", pConfig->hExclusiveTrustedPeople);
++        TRACE("dwExclusiveFlags %lx\n", pConfig->dwExclusiveFlags);
++        if (pConfig->dwExclusiveFlags)
++            FIXME("dwExclusiveFlags %lx not supported\n", pConfig->dwExclusiveFlags);
++    }
+     ret = CRYPT_CheckRestrictedRoot(pConfig->hRestrictedRoot);
+     if (!ret)
+     {
+--- a/include/wincrypt.h	2026-08-26 13:49:48.000000000 -0300
++++ b/include/wincrypt.h	2026-09-12 18:47:59.522438786 -0300
+@@ -3499,7 +3499,8 @@
+     DWORD       MaximumCachedCertificates;
+     DWORD       CycleDetectionModulus;
+     HCERTSTORE  hExclusiveRoot;
+-    HCERTSTORE  hExclusiveRootTrustedPeople;
++    HCERTSTORE  hExclusiveTrustedPeople;
++    DWORD       dwExclusiveFlags;
+ } CERT_CHAIN_ENGINE_CONFIG, *PCERT_CHAIN_ENGINE_CONFIG;
+ 
+ /* message-related definitions */


### PR DESCRIPTION
## Summary

Warcraft III: Reforged 3.0 (the September 2026 expansion update) fails Battle.net login under GE-Proton 11-x with:

> There was an error in handling the request. Please check your VPN

The updated `ClientSdk.dll` validates the Battle.net TLS certificate through `CertCreateCertificateChainEngine()` and passes the current Windows `CERT_CHAIN_ENGINE_CONFIG` (88 bytes on x64, includes `dwExclusiveFlags`). The Proton wine only accepts `sizeof(CERT_CHAIN_ENGINE_CONFIG_NO_EXCLUSIVE_ROOT)` (64) and its own 80-byte `CERT_CHAIN_ENGINE_CONFIG` (no `dwExclusiveFlags`) and returns `E_INVALIDARG`, so the game cannot build a chain engine, treats the connection as untrusted and aborts login.

This adds a hotfix patch backporting the upstream Wine fix (in Wine 11.6):

- `02bb0a34` crypt32: Trace CERT_CHAIN_ENGINE_CONFIG fields in CertCreateCertificateChainEngine().
- `eef8e97d` crypt32: Don't access CERT_CHAIN_ENGINE_CONFIG::dwExclusiveFlags without checking size.
- `c7cc9be8` crypt32: Also accept CERT_CHAIN_ENGINE_CONFIG without dwExclusiveFlags.

plus the `include/wincrypt.h` `dwExclusiveFlags` field they depend on, and applies it from `protonprep-valve-staging.sh` next to the other pending crypt32 hotfixes.

## Testing

- Built `crypt32.dll` (x86_64 and i386) from the GE-Proton11-6 wine submodule commit (`9358696`) with this patch, dropped into a copy of GE-Proton11-6: Warcraft III: Reforged 3.0 logs in and plays normally again. Without the patch the VPN error reproduces every time.
- Diagnosed with `WINEDEBUG=+winsock,+secur32`: all TLS handshakes complete, the game queries `SECPKG_ATTR_REMOTE_CERT_CONTEXT` and immediately drops the connection; `ClientSdk.dll` imports `CertCreateCertificateChainEngine`.
- The patch applies cleanly (`patch -p1 --dry-run`) against the wine submodule currently on master (`00e6398`).

Ready-made build for users in the meantime: https://github.com/FerMPY/wc3-reforged-proton-fix
