### PR TITLE
crypt32: fix Warcraft III login and preserve legacy certificate-chain configurations

### DIFF
--- a/WC3-CERTFIX.md
+++ b/WC3-CERTFIX.md
@@ -1,0 +1,73 @@
+# Warcraft III certificate-chain compatibility fix
+
+This community GE-Proton build fixes the Warcraft III 3.0.0.24268 login failure
+that displays "Please check your VPN" when its ClientSdk requests an 88-byte
+`CERT_CHAIN_ENGINE_CONFIG` on 64-bit Wine. The pinned Wine revision rejects
+that layout with `E_INVALIDARG`, interrupting authentication after TLS connects.
+
+The patch series backports four upstream Wine commits:
+
+- `2012949a0de0b550d221c5514f5632efcd8c3df2`: update the public structure.
+- `02bb0a34ad51a7ac4eda1f50d6ac3b7938487185`: trace configuration fields.
+- `eef8e97dd335beccb23f3b13d4f4ad715f23f359`: guard access to newer fields.
+- `c7cc9be89613cbe21e1af9ffc7b7e8352feac488`: retain the previous layout.
+
+A follow-up preserves `hExclusiveRoot` handling for the older 80-byte layout
+and adds guarded-memory and exclusive-root trust regression tests. Supported
+64-bit layouts are 64, 80 and 88 bytes; invalid sizes remain rejected.
+Certificate validation and game ownership checks remain enabled.
+
+## Using the build
+
+Install `GE-Proton11-WC3-CertFix` alongside your existing compatibility tools.
+Close Battle.net, its background agent and Warcraft before switching runners.
+Keep the existing Battle.net prefix and run Warcraft from that Battle.net
+instance so both use the same Proton build. Switching only a separate Warcraft
+shortcut can leave Battle.net running under the previous Wine server.
+
+With Steam, extract the release tarball into Steam's `compatibilitytools.d`
+directory, fully restart Steam, and select `GE-Proton11-WC3-CertFix` in the
+Battle.net shortcut's compatibility settings. This build declares Steam Linux
+Runtime 4 (`appid 4183110`) as its runtime dependency.
+
+For non-Steam launchers, use an umu-enabled setup as described in the upstream
+[README](README.md). A direct Proton launcher also worked on the test host, but
+requires compatible host libraries; retain its existing prefix and settings.
+
+## Build
+
+Start with a fresh recursive checkout of this fork, Git, GNU Make and a working
+Podman installation. The build downloads the SDK container and uses its
+compilers. See [README.md](README.md#building) for the GE workflow. From the
+checkout root:
+
+```sh
+./patches/protonprep-valve-staging.sh > patchlog.txt 2>&1
+# Inspect patchlog.txt for failures before proceeding.
+mkdir build
+cd build
+../configure.sh --build-name=GE-Proton11-WC3-CertFix --container-engine=podman
+make -j8 redist
+```
+
+The tested build used the Steam Runtime 4 SDK image
+`registry.gitlab.steamos.cloud/proton/steamrt4/sdk/x86_64:4.0.20260714.251823-0`.
+It is based on GE commit `0b8c4d30d76abb74cc5cc4efdbadb410db00455f` and Wine
+submodule commit `00e639898e01f8dd6fbee3851bd4c1e412c5b875`.
+The distributed binary was built before the packaging commit, so its embedded
+version string still refers to that GE base revision.
+
+## Validation
+
+- All five patches apply to the pinned Wine source files in sequence.
+- Full GE `make redist` build completed successfully.
+- Standalone 64-bit ABI probe: 64/80/88-byte layouts accepted; 96-byte layout
+  rejected. The previous runner rejected the 88-byte layout.
+- Standalone guarded-memory and exclusive-root trust regression: zero failures.
+  The added Wine test exercises these cases; the full crypt32 test suite was
+  not run.
+- The user confirmed Battle.net and Warcraft III launch and authenticate with
+  this build on Arch Linux, using the existing Battle.net prefix.
+
+This is a community build, not an official GE-Proton release. Keep the bundled
+licenses and consult the individual source components for their license terms.

--- a/patches/protonprep-valve-staging.sh
+++ b/patches/protonprep-valve-staging.sh
@@ -318,6 +318,14 @@ apply_all_in_dir() {
     echo "WINE: -HOTFIX- Reject unsupported NCrypt-only private-key requests"
     apply_patch "../patches/wine-hotfixes/pending/crypt32-reject-ncrypt-only-private-keys.patch"
 
+    # Warcraft III 3.0: modern CERT_CHAIN_ENGINE_CONFIG used by ClientSdk login.
+    # Upstream Wine fixes for #59531 and the legacy-layout regression #59600.
+    apply_patch "../patches/wine-hotfixes/pending/crypt32-wc3-modern-chain-engine-config.patch"
+    apply_patch "../patches/wine-hotfixes/pending/crypt32-wc3-trace-chain-engine-config.patch"
+    apply_patch "../patches/wine-hotfixes/pending/crypt32-wc3-check-exclusive-flags-size.patch"
+    apply_patch "../patches/wine-hotfixes/pending/crypt32-wc3-accept-legacy-chain-engine-config.patch"
+    apply_patch "../patches/wine-hotfixes/pending/crypt32-wc3-preserve-exclusive-root-and-test-layouts.patch"
+
     echo "WINE: -HOTFIX- Add GetFileVersionInfoByHandle version export stub"
     apply_patch "../patches/wine-hotfixes/pending/version-GetFileVersionInfoByHandle-stub.patch"
 

--- a/patches/wine-hotfixes/pending/crypt32-wc3-accept-legacy-chain-engine-config.patch
+++ b/patches/wine-hotfixes/pending/crypt32-wc3-accept-legacy-chain-engine-config.patch
@@ -1,0 +1,50 @@
+From c7cc9be89613cbe21e1af9ffc7b7e8352feac488 Mon Sep 17 00:00:00 2001
+From: Hans Leidekker <hans@codeweavers.com>
+Date: Tue, 31 Mar 2026 22:54:12 +0200
+Subject: [PATCH] crypt32: Also accept CERT_CHAIN_ENGINE_CONFIG without
+ dwExclusiveFlags.
+
+Wine-Bug: https://bugs.winehq.org/show_bug.cgi?id=59600
+---
+ dlls/crypt32/chain.c | 21 +++++++++++++++++++--
+ 1 file changed, 19 insertions(+), 2 deletions(-)
+
+diff --git a/dlls/crypt32/chain.c b/dlls/crypt32/chain.c
+index cb9d0c7acb36..f3c97c3588fb 100644
+--- a/dlls/crypt32/chain.c
++++ b/dlls/crypt32/chain.c
+@@ -221,6 +221,22 @@ typedef struct _CERT_CHAIN_ENGINE_CONFIG_NO_EXCLUSIVE_ROOT
+     DWORD       CycleDetectionModulus;
+ } CERT_CHAIN_ENGINE_CONFIG_NO_EXCLUSIVE_ROOT;
+ 
++typedef struct _CERT_CHAIN_ENGINE_CONFIG_NO_EXCLUSIVE_FLAGS
++{
++    DWORD       cbSize;
++    HCERTSTORE  hRestrictedRoot;
++    HCERTSTORE  hRestrictedTrust;
++    HCERTSTORE  hRestrictedOther;
++    DWORD       cAdditionalStore;
++    HCERTSTORE *rghAdditionalStore;
++    DWORD       dwFlags;
++    DWORD       dwUrlRetrievalTimeout;
++    DWORD       MaximumCachedCertificates;
++    DWORD       CycleDetectionModulus;
++    HCERTSTORE  hExclusiveRoot;
++    HCERTSTORE  hExclusiveTrustedPeople;
++} CERT_CHAIN_ENGINE_CONFIG_NO_EXCLUSIVE_FLAGS;
++
+ BOOL WINAPI CertCreateCertificateChainEngine(PCERT_CHAIN_ENGINE_CONFIG pConfig,
+  HCERTCHAINENGINE *phChainEngine)
+ {
+@@ -236,8 +252,9 @@ BOOL WINAPI CertCreateCertificateChainEngine(PCERT_CHAIN_ENGINE_CONFIG pConfig,
+     TRACE("dwUrlRetrievalTimeout %lu\n", pConfig->dwUrlRetrievalTimeout);
+     TRACE("MaximumCachedCertificates %lu\n", pConfig->MaximumCachedCertificates);
+     TRACE("CycleDetectionModulus %lu\n", pConfig->CycleDetectionModulus);
+-    if (pConfig->cbSize != sizeof(CERT_CHAIN_ENGINE_CONFIG_NO_EXCLUSIVE_ROOT)
+-     && pConfig->cbSize != sizeof(CERT_CHAIN_ENGINE_CONFIG))
++    if (pConfig->cbSize != sizeof(CERT_CHAIN_ENGINE_CONFIG_NO_EXCLUSIVE_ROOT) &&
++        pConfig->cbSize != sizeof(CERT_CHAIN_ENGINE_CONFIG_NO_EXCLUSIVE_FLAGS) &&
++        pConfig->cbSize != sizeof(CERT_CHAIN_ENGINE_CONFIG))
+     {
+         SetLastError(E_INVALIDARG);
+         return FALSE;

--- a/patches/wine-hotfixes/pending/crypt32-wc3-check-exclusive-flags-size.patch
+++ b/patches/wine-hotfixes/pending/crypt32-wc3-check-exclusive-flags-size.patch
@@ -1,0 +1,43 @@
+From eef8e97dd335beccb23f3b13d4f4ad715f23f359 Mon Sep 17 00:00:00 2001
+From: Yuxuan Shui <yshui@codeweavers.com>
+Date: Fri, 20 Mar 2026 09:23:46 +0000
+Subject: [PATCH] crypt32: Don't access
+ CERT_CHAIN_ENGINE_CONFIG::dwExclusiveFlags without checking size.
+
+Found by ASan.
+---
+ dlls/crypt32/chain.c | 15 ++++++++++-----
+ 1 file changed, 10 insertions(+), 5 deletions(-)
+
+diff --git a/dlls/crypt32/chain.c b/dlls/crypt32/chain.c
+index 6e0e55b9e5a4..cb9d0c7acb36 100644
+--- a/dlls/crypt32/chain.c
++++ b/dlls/crypt32/chain.c
+@@ -236,17 +236,22 @@ BOOL WINAPI CertCreateCertificateChainEngine(PCERT_CHAIN_ENGINE_CONFIG pConfig,
+     TRACE("dwUrlRetrievalTimeout %lu\n", pConfig->dwUrlRetrievalTimeout);
+     TRACE("MaximumCachedCertificates %lu\n", pConfig->MaximumCachedCertificates);
+     TRACE("CycleDetectionModulus %lu\n", pConfig->CycleDetectionModulus);
+-    TRACE("hExclusiveRoot %p\n", pConfig->hExclusiveRoot);
+-    TRACE("hExclusiveTrustedPeople %p\n", pConfig->hExclusiveTrustedPeople);
+-    TRACE("dwExclusiveFlags %lx\n", pConfig->dwExclusiveFlags);
+-    if (pConfig->dwExclusiveFlags) FIXME("dwExclusiveFlags %lx not supported\n", pConfig->dwExclusiveFlags);
+-
+     if (pConfig->cbSize != sizeof(CERT_CHAIN_ENGINE_CONFIG_NO_EXCLUSIVE_ROOT)
+      && pConfig->cbSize != sizeof(CERT_CHAIN_ENGINE_CONFIG))
+     {
+         SetLastError(E_INVALIDARG);
+         return FALSE;
+     }
++
++    if (pConfig->cbSize == sizeof(CERT_CHAIN_ENGINE_CONFIG))
++    {
++        TRACE("hExclusiveRoot %p\n", pConfig->hExclusiveRoot);
++        TRACE("hExclusiveTrustedPeople %p\n", pConfig->hExclusiveTrustedPeople);
++        TRACE("dwExclusiveFlags %lx\n", pConfig->dwExclusiveFlags);
++        if (pConfig->dwExclusiveFlags)
++            FIXME("dwExclusiveFlags %lx not supported\n", pConfig->dwExclusiveFlags);
++    }
++
+     ret = CRYPT_CheckRestrictedRoot(pConfig->hRestrictedRoot);
+     if (!ret)
+     {

--- a/patches/wine-hotfixes/pending/crypt32-wc3-modern-chain-engine-config.patch
+++ b/patches/wine-hotfixes/pending/crypt32-wc3-modern-chain-engine-config.patch
@@ -1,0 +1,26 @@
+From 2012949a0de0b550d221c5514f5632efcd8c3df2 Mon Sep 17 00:00:00 2001
+From: Hans Leidekker <hans@codeweavers.com>
+Date: Mon, 16 Mar 2026 13:26:35 +0100
+Subject: [PATCH] include: Update definition of CERT_CHAIN_ENGINE_CONFIG.
+
+And fix spelling of hExclusiveTrustedPeople.
+
+Wine-Bug: https://bugs.winehq.org/show_bug.cgi?id=59531
+---
+ include/wincrypt.h | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/include/wincrypt.h b/include/wincrypt.h
+index e3a7ad0eb242..9c42586700fb 100644
+--- a/include/wincrypt.h
++++ b/include/wincrypt.h
+@@ -3497,7 +3497,8 @@ typedef struct _CERT_CHAIN_ENGINE_CONFIG
+     DWORD       MaximumCachedCertificates;
+     DWORD       CycleDetectionModulus;
+     HCERTSTORE  hExclusiveRoot;
+-    HCERTSTORE  hExclusiveRootTrustedPeople;
++    HCERTSTORE  hExclusiveTrustedPeople;
++    DWORD       dwExclusiveFlags;
+ } CERT_CHAIN_ENGINE_CONFIG, *PCERT_CHAIN_ENGINE_CONFIG;
+ 
+ /* message-related definitions */

--- a/patches/wine-hotfixes/pending/crypt32-wc3-preserve-exclusive-root-and-test-layouts.patch
+++ b/patches/wine-hotfixes/pending/crypt32-wc3-preserve-exclusive-root-and-test-layouts.patch
@@ -1,0 +1,118 @@
+From: Codex <codex@local>
+Subject: [PATCH] crypt32: Preserve legacy exclusive roots and test chain configuration layouts.
+
+Backport follow-up: increasing the public structure size must not make
+CRYPT_CreateChainEngine ignore hExclusiveRoot in the existing 80-byte ABI.
+Exercise all supported layouts at a guard page and preserve trust validation.
+
+--- a/dlls/crypt32/chain.c
++++ b/dlls/crypt32/chain.c
+@@ -120,7 +120,7 @@
+     if (root) {
+         root = CertDuplicateStore(root);
+     } else {
+-        if(config->cbSize >= sizeof(CERT_CHAIN_ENGINE_CONFIG) && config->hExclusiveRoot)
++        if(config->cbSize >= FIELD_OFFSET(CERT_CHAIN_ENGINE_CONFIG, dwExclusiveFlags) && config->hExclusiveRoot)
+             root = CertDuplicateStore(config->hExclusiveRoot);
+         else if (config->hRestrictedRoot)
+             root = CertDuplicateStore(config->hRestrictedRoot);
+--- a/dlls/crypt32/tests/chain.c
++++ b/dlls/crypt32/tests/chain.c
+@@ -119,6 +119,89 @@
+         "Expected CRYPT_E_NOT_FOUND or ERROR_FILE_NOT_FOUND, got %08lx\n", GetLastError());
+ 
+     CertCloseStore(store, 0);
++}
++
++static void testChainEngineConfigLayouts(void)
++{
++    static const DWORD sizes[] = {
++        sizeof(CERT_CHAIN_ENGINE_CONFIG_NO_EXCLUSIVE_ROOT),
++        FIELD_OFFSET(CERT_CHAIN_ENGINE_CONFIG, dwExclusiveFlags),
++        sizeof(CERT_CHAIN_ENGINE_CONFIG)
++    };
++    CERT_CHAIN_PARA para = { sizeof(para) };
++    CERT_CHAIN_ENGINE_CONFIG invalid = { 0 }, *config;
++    PCCERT_CHAIN_CONTEXT chain;
++    PCCERT_CONTEXT cert;
++    HCERTCHAINENGINE engine;
++    HCERTSTORE store;
++    SYSTEM_INFO info;
++    DWORD old_protect, i;
++    BYTE *memory;
++    BOOL ret;
++
++    GetSystemInfo(&info);
++    memory = VirtualAlloc(NULL, info.dwPageSize * 2, MEM_RESERVE | MEM_COMMIT, PAGE_READWRITE);
++    ok(!!memory, "VirtualAlloc failed: %lu\n", GetLastError());
++    if (!memory) return;
++    ret = VirtualProtect(memory + info.dwPageSize, info.dwPageSize, PAGE_NOACCESS, &old_protect);
++    ok(ret, "VirtualProtect failed: %lu\n", GetLastError());
++    if (!ret)
++    {
++        VirtualFree(memory, 0, MEM_RELEASE);
++        return;
++    }
++
++    store = CertOpenStore(CERT_STORE_PROV_MEMORY, 0, 0, CERT_STORE_CREATE_NEW_FLAG, NULL);
++    ok(!!store, "CertOpenStore failed: %lu\n", GetLastError());
++    ret = CertAddEncodedCertificateToStore(store, X509_ASN_ENCODING, selfSignedCert,
++        sizeof(selfSignedCert), CERT_STORE_ADD_ALWAYS, &cert);
++    ok(ret, "CertAddEncodedCertificateToStore failed: %lu\n", GetLastError());
++    if (!ret)
++    {
++        CertCloseStore(store, 0);
++        VirtualFree(memory, 0, MEM_RELEASE);
++        return;
++    }
++
++    for (i = 0; i < ARRAY_SIZE(sizes); ++i)
++    {
++        /* Each legacy structure ends at a guard page: no reading newer fields. */
++        config = (CERT_CHAIN_ENGINE_CONFIG *)(memory + info.dwPageSize - sizes[i]);
++        memset(config, 0, sizes[i]);
++        config->cbSize = sizes[i];
++        if (i) config->hExclusiveRoot = store;
++        engine = NULL;
++        ret = CertCreateCertificateChainEngine(config, &engine);
++        ok(ret, "layout %lu: engine creation failed: %08lx\n", sizes[i], GetLastError());
++        if (!ret) continue;
++        if (i)
++        {
++            /* The old 80-byte layout must still honor its exclusive root. */
++            chain = NULL;
++            ret = CertGetCertificateChain(engine, cert, NULL, NULL, &para,
++                CERT_CHAIN_CACHE_ONLY_URL_RETRIEVAL, NULL, &chain);
++            ok(ret, "layout %lu: chain creation failed: %08lx\n", sizes[i], GetLastError());
++            if (ret)
++            {
++                ok(!(chain->TrustStatus.dwErrorStatus & CERT_TRUST_IS_UNTRUSTED_ROOT),
++                    "layout %lu: exclusive root ignored, trust status %08lx\n",
++                    sizes[i], chain->TrustStatus.dwErrorStatus);
++                CertFreeCertificateChain(chain);
++            }
++        }
++        CertFreeCertificateChainEngine(engine);
++    }
++
++    invalid.cbSize = sizeof(invalid) + sizeof(void *);
++    SetLastError(0xdeadbeef);
++    ret = CertCreateCertificateChainEngine(&invalid, &engine);
++    ok(!ret && GetLastError() == E_INVALIDARG,
++        "Invalid layout accepted: ret %d, error %08lx\n", ret, GetLastError());
++    if (ret) CertFreeCertificateChainEngine(engine);
++
++    CertFreeCertificateContext(cert);
++    CertCloseStore(store, 0);
++    VirtualFree(memory, 0, MEM_RELEASE);
+ }
+ 
+ static const BYTE bigCert[] = { 0x30, 0x7a, 0x02, 0x01, 0x01, 0x30, 0x02, 0x06,
+@@ -5570,6 +5653,7 @@
+ START_TEST(chain)
+ {
+     testCreateCertChainEngine();
++    testChainEngineConfigLayouts();
+     testVerifyCertChainPolicy();
+     testGetCertChain();
+     test_CERT_CHAIN_PARA_cbSize();

--- a/patches/wine-hotfixes/pending/crypt32-wc3-trace-chain-engine-config.patch
+++ b/patches/wine-hotfixes/pending/crypt32-wc3-trace-chain-engine-config.patch
@@ -1,0 +1,34 @@
+From 02bb0a34ad51a7ac4eda1f50d6ac3b7938487185 Mon Sep 17 00:00:00 2001
+From: Hans Leidekker <hans@codeweavers.com>
+Date: Mon, 16 Mar 2026 13:28:43 +0100
+Subject: [PATCH] crypt32: Trace CERT_CHAIN_ENGINE_CONFIG fields in
+ CertCreateCertificateChainEngine().
+
+---
+ dlls/crypt32/chain.c | 13 +++++++++++++
+ 1 file changed, 13 insertions(+)
+
+diff --git a/dlls/crypt32/chain.c b/dlls/crypt32/chain.c
+index 1b38e789f159..6e0e55b9e5a4 100644
+--- a/dlls/crypt32/chain.c
++++ b/dlls/crypt32/chain.c
+@@ -227,6 +227,19 @@ BOOL WINAPI CertCreateCertificateChainEngine(PCERT_CHAIN_ENGINE_CONFIG pConfig,
+     BOOL ret;
+ 
+     TRACE("(%p, %p)\n", pConfig, phChainEngine);
++    TRACE("cbSize %lu\n", pConfig->cbSize);
++    TRACE("hRestrictedRoot %p\n", pConfig->hRestrictedRoot);
++    TRACE("hRestrictedTrust %p\n", pConfig->hRestrictedTrust);
++    TRACE("hRestrictedOther %p\n", pConfig->hRestrictedOther);
++    TRACE("cAdditionalStore %lu\n", pConfig->cAdditionalStore);
++    TRACE("dwFlags %lx\n", pConfig->dwFlags);
++    TRACE("dwUrlRetrievalTimeout %lu\n", pConfig->dwUrlRetrievalTimeout);
++    TRACE("MaximumCachedCertificates %lu\n", pConfig->MaximumCachedCertificates);
++    TRACE("CycleDetectionModulus %lu\n", pConfig->CycleDetectionModulus);
++    TRACE("hExclusiveRoot %p\n", pConfig->hExclusiveRoot);
++    TRACE("hExclusiveTrustedPeople %p\n", pConfig->hExclusiveTrustedPeople);
++    TRACE("dwExclusiveFlags %lx\n", pConfig->dwExclusiveFlags);
++    if (pConfig->dwExclusiveFlags) FIXME("dwExclusiveFlags %lx not supported\n", pConfig->dwExclusiveFlags);
+ 
+     if (pConfig->cbSize != sizeof(CERT_CHAIN_ENGINE_CONFIG_NO_EXCLUSIVE_ROOT)
+      && pConfig->cbSize != sizeof(CERT_CHAIN_ENGINE_CONFIG))


### PR DESCRIPTION
<html><head></head><body><h2><span>Background</span></h2><p><span>Warcraft III: Reforged 3.0.0.24268 can fail Battle.net authentication under GE-Proton with:</span></p><blockquote><p><span><img width="1913" height="1033" alt="image" src="https://github.com/user-attachments/assets/f4338d68-2a5a-40dd-bf90-e83988a61ea7" /></span></p></blockquote><p><span>The observed failure occurs after the network connection and TLS handshake. The updated </span><code><span>ClientSdk.dll</span></code><span> calls </span><code><span>CertCreateCertificateChainEngine()</span></code><span> with an 88-byte </span><code><span>CERT_CHAIN_ENGINE_CONFIG</span></code><span>, which the Wine revision pinned by this GE base rejects with </span><code><span>E_INVALIDARG</span></code><span>.</span></p><p><span>This prevents authentication from completing and produces the generic VPN error.</span></p><p><span>Related: #764 proposed a backport for the same issue. This PR also addresses a compatibility regression affecting older callers that supply an exclusive root certificate store.</span></p><h2><span>Technical explanation</span></h2><p><span>On 64-bit systems, the relevant configuration layouts are:</span></p>
Size | Configuration
-- | --
64 bytes | Basic chain-engine configuration
80 bytes | Includes hExclusiveRoot and hExclusiveTrustedPeople
88 bytes | Also includes dwExclusiveFlags and alignment padding

<p><span>The pinned Wine implementation recognizes the 64- and 80-byte layouts. Updating the public structure makes the current layout 88 bytes, but compatibility requires retaining recognition of both older layouts.</span></p><p><span>This PR backports the upstream Wine changes that update the structure, recognize the supported layouts, and guard access to the newer fields:</span></p><ul><li><p><a href="https://github.com/wine-mirror/wine/commit/2012949a0de0b550d221c5514f5632efcd8c3df2"><span>2012949a</span></a><span>: update </span><code><span>CERT_CHAIN_ENGINE_CONFIG</span></code><span>.</span></p></li><li><p><a href="https://github.com/wine-mirror/wine/commit/02bb0a34ad51a7ac4eda1f50d6ac3b7938487185"><span>02bb0a34</span></a><span>: add configuration tracing.</span></p></li><li><p><a href="https://github.com/wine-mirror/wine/commit/eef8e97dd335beccb23f3b13d4f4ad715f23f359"><span>eef8e97d</span></a><span>: check the layout before accessing newer fields.</span></p></li><li><p><a href="https://github.com/wine-mirror/wine/commit/c7cc9be89613cbe21e1af9ffc7b7e8352feac488"><span>c7cc9be8</span></a><span>: retain acceptance of the layout without </span><code><span>dwExclusiveFlags</span></code><span>.</span></p></li></ul><h2><span>Preserving existing certificate-root behavior</span></h2><p><span>Accepting the older layout alone does not preserve its behavior.</span></p><p><code><span>CRYPT_CreateChainEngine()</span></code><span> currently checks:</span></p><pre><code><span>config-&gt;cbSize &gt;= sizeof(CERT_CHAIN_ENGINE_CONFIG)</span></code></pre><p><span>before honoring </span><code><span>hExclusiveRoot</span></code><span>. Increasing the structure size from 80 to 88 bytes makes this check fail for an older 80-byte caller, even though that caller supplies the field.</span></p><p><span>The result is that Wine accepts the configuration but ignores its exclusive root store. For example, an application relying on a private root certificate could fall back to the system root store and subsequently fail certificate validation.</span></p><p><span>The additional follow-up patch checks:</span></p><pre><code><span>config-&gt;cbSize &gt;=
    FIELD_OFFSET(CERT_CHAIN_ENGINE_CONFIG, dwExclusiveFlags)</span></code></pre><p><span>This preserves exclusive-root handling for the supported older layout while retaining the public API’s exact-size validation.</span></p><h2><span>Regression coverage</span></h2><p><span>The follow-up patch adds </span><code><span>testChainEngineConfigLayouts()</span></code><span> to the crypt32 chain tests, covering:</span></p><ul><li><p><strong><span>Supported layouts:</span></strong><span> creation succeeds for the basic, exclusive-root, and current configurations.</span></p></li><li><p><strong><span>Memory boundaries:</span></strong><span> each configuration ends immediately before an inaccessible page, exposing reads beyond the supplied structure.</span></p></li><li><p><strong><span>Exclusive-root handling:</span></strong><span> both layouts containing </span><code><span>hExclusiveRoot</span></code><span> use an explicitly supplied test root without reporting </span><code><span>CERT_TRUST_IS_UNTRUSTED_ROOT</span></code><span>.</span></p></li><li><p><strong><span>Invalid sizes:</span></strong><span> an unsupported configuration size remains rejected with </span><code><span>E_INVALIDARG</span></code><span>.</span></p></li></ul><p><span>The trust assertion specifically checks root-store handling; it is not a comprehensive certificate-policy test.</span></p><h2><span>Validation performed</span></h2><ul><li><p><span>Applied all five patches successfully to Wine revision </span><code><span>00e639898e01f8dd6fbee3851bd4c1e412c5b875</span></code><span>.</span></p></li><li><p><span>Completed a full GE-Proton </span><code><span>make redist</span></code><span> build.</span></p></li><li><p><span>Ran a standalone 64-bit ABI probe:</span></p><ul><li><p><span>64-, 80-, and 88-byte layouts accepted.</span></p></li><li><p><span>Invalid 96-byte layout rejected.</span></p></li><li><p><span>The previous runner rejected the 88-byte layout.</span></p></li></ul></li><li><p><span>Ran the standalone guarded-memory and exclusive-root regression checks with zero failures.</span></p></li><li><p><span>Manually verified successful Battle.net and Warcraft III authentication on Arch Linux using the existing Battle.net prefix and the patched runner.</span></p></li></ul><p><span>The full Wine crypt32 test suite and separate 32-bit runtime probes were not run.</span></p><h2><span>Scope and limitations</span></h2><p><span>The patch series is registered in </span><code><span>protonprep-valve-staging.sh</span></code><span>, and </span><code><span>WC3-CERTFIX.md</span></code><span> documents the issue, build procedure, and validation.</span></p><p><span>Certificate validation and game ownership checks remain enabled. The change restores compatibility with the configuration passed by the updated client.</span></p><p><span>This does not implement all newer certificate-engine options: nonzero </span><code><span>dwExclusiveFlags</span></code><span> values retain the upstream unsupported-feature diagnostic.</span></p><p><span>The four upstream patches retain their original attribution. The additional follow-up preserves legacy exclusive-root behavior and adds regression coverage.</span></p></body></html>## Background

Warcraft III: Reforged 3.0.0.24268 can fail Battle.net authentication under GE-Proton with:

> Please check your VPN

The observed failure occurs after the network connection and TLS handshake. The updated `ClientSdk.dll` calls `CertCreateCertificateChainEngine()` with an 88-byte `CERT_CHAIN_ENGINE_CONFIG`, which the Wine revision pinned by this GE base rejects with `E_INVALIDARG`.

This prevents authentication from completing and produces the generic VPN error.

Related: #764 proposed a backport for the same issue. This PR also addresses a compatibility regression affecting older callers that supply an exclusive root certificate store.

## Technical explanation

On 64-bit systems, the relevant configuration layouts are:

| Size | Configuration |
|---|---|
| 64 bytes | Basic chain-engine configuration |
| 80 bytes | Includes `hExclusiveRoot` and `hExclusiveTrustedPeople` |
| 88 bytes | Also includes `dwExclusiveFlags` and alignment padding |

The pinned Wine implementation recognizes the 64- and 80-byte layouts. Updating the public structure makes the current layout 88 bytes, but compatibility requires retaining recognition of both older layouts.

This PR backports the upstream Wine changes that update the structure, recognize the supported layouts, and guard access to the newer fields:

- [[2012949a](https://github.com/wine-mirror/wine/commit/2012949a0de0b550d221c5514f5632efcd8c3df2)](https://github.com/wine-mirror/wine/commit/2012949a0de0b550d221c5514f5632efcd8c3df2): update `CERT_CHAIN_ENGINE_CONFIG`.
- [[02bb0a34](https://github.com/wine-mirror/wine/commit/02bb0a34ad51a7ac4eda1f50d6ac3b7938487185)](https://github.com/wine-mirror/wine/commit/02bb0a34ad51a7ac4eda1f50d6ac3b7938487185): add configuration tracing.
- [[eef8e97d](https://github.com/wine-mirror/wine/commit/eef8e97dd335beccb23f3b13d4f4ad715f23f359)](https://github.com/wine-mirror/wine/commit/eef8e97dd335beccb23f3b13d4f4ad715f23f359): check the layout before accessing newer fields.
- [[c7cc9be8](https://github.com/wine-mirror/wine/commit/c7cc9be89613cbe21e1af9ffc7b7e8352feac488)](https://github.com/wine-mirror/wine/commit/c7cc9be89613cbe21e1af9ffc7b7e8352feac488): retain acceptance of the layout without `dwExclusiveFlags`.

## Preserving existing certificate-root behavior

Accepting the older layout alone does not preserve its behavior.

`CRYPT_CreateChainEngine()` currently checks:

```c
config->cbSize >= sizeof(CERT_CHAIN_ENGINE_CONFIG)
```

before honoring `hExclusiveRoot`. Increasing the structure size from 80 to 88 bytes makes this check fail for an older 80-byte caller, even though that caller supplies the field.

The result is that Wine accepts the configuration but ignores its exclusive root store. For example, an application relying on a private root certificate could fall back to the system root store and subsequently fail certificate validation.

The additional follow-up patch checks:

```c
config->cbSize >=
    FIELD_OFFSET(CERT_CHAIN_ENGINE_CONFIG, dwExclusiveFlags)
```

This preserves exclusive-root handling for the supported older layout while retaining the public API’s exact-size validation.

## Regression coverage

The follow-up patch adds `testChainEngineConfigLayouts()` to the crypt32 chain tests, covering:

- **Supported layouts:** creation succeeds for the basic, exclusive-root, and current configurations.
- **Memory boundaries:** each configuration ends immediately before an inaccessible page, exposing reads beyond the supplied structure.
- **Exclusive-root handling:** both layouts containing `hExclusiveRoot` use an explicitly supplied test root without reporting `CERT_TRUST_IS_UNTRUSTED_ROOT`.
- **Invalid sizes:** an unsupported configuration size remains rejected with `E_INVALIDARG`.

The trust assertion specifically checks root-store handling; it is not a comprehensive certificate-policy test.

## Validation performed

- Applied all five patches successfully to Wine revision `00e639898e01f8dd6fbee3851bd4c1e412c5b875`.
- Completed a full GE-Proton `make redist` build.
- Ran a standalone 64-bit ABI probe:
  - 64-, 80-, and 88-byte layouts accepted.
  - Invalid 96-byte layout rejected.
  - The previous runner rejected the 88-byte layout.
- Ran the standalone guarded-memory and exclusive-root regression checks with zero failures.
- Manually verified successful Battle.net and Warcraft III authentication on Arch Linux using the existing Battle.net prefix and the patched runner.

The full Wine crypt32 test suite and separate 32-bit runtime probes were not run.

## Scope and limitations

The patch series is registered in `protonprep-valve-staging.sh`, and `WC3-CERTFIX.md` documents the issue, build procedure, and validation.

Certificate validation and game ownership checks remain enabled. The change restores compatibility with the configuration passed by the updated client.

This does not implement all newer certificate-engine options: nonzero `dwExclusiveFlags` values retain the upstream unsupported-feature diagnostic.

The four upstream patches retain their original attribution. The additional follow-up preserves legacy exclusive-root behavior and adds regression coverage.